### PR TITLE
treść: usunięcie anglicyzmów z widocznego tekstu (12 plików)

### DIFF
--- a/benchmarks.html
+++ b/benchmarks.html
@@ -29,7 +29,7 @@
     <div class="board">
       <div class="team"><div class="tg">punkt odniesienia</div><div class="nm">Bielik-11B-v3</div></div>
       <div class="cnt"><span class="b" id="sb">·</span><span class="d">:</span><span class="q" id="sq">·</span></div>
-      <div class="team"><div class="tg">challenger</div><div class="nm">Qwen3.5-9B</div></div>
+      <div class="team"><div class="tg">pretendent</div><div class="nm">Qwen3.5-9B</div></div>
       <div class="bfoot" id="sbfoot">—</div>
     </div>
 

--- a/datasety.html
+++ b/datasety.html
@@ -22,8 +22,8 @@
     <div class="tbl"><table><thead><tr><th>Dataset</th><th>Rola</th><th>Metryka</th><th>Rozmiar</th><th>Status</th></tr></thead><tbody>
       <tr><td><div class="dn"><a href="https://huggingface.co/datasets/amu-cai/llmzszl-dataset" rel="noopener">LLMzSzŁ</a></div><div class="ds">egzaminy państwowe CKE · 154 domeny</div></td><td>główny agregat</td><td>accuracy MCQ</td><td>18 821</td><td><span class="chip acc">publiczny</span></td></tr>
       <tr><td><div class="dn"><a href="https://huggingface.co/datasets/speakleash/PES-2018-2022" rel="noopener">PES</a></div><div class="ds">egzaminy specjalizacyjne</div></td><td>egzamin zawodowy</td><td>accuracy</td><td>70 010</td><td><span class="chip acc">publiczny</span></td></tr>
-      <tr><td><div class="dn"><a href="https://huggingface.co/datasets/clarin-pl/poquad" rel="noopener">PoQuAD</a></div><div class="ds">SQuAD 2.0, natywnie PL, no-answer</div></td><td>grounding / refusal</td><td>F1 + sędzia-LLM</td><td>~52 000</td><td><span class="chip acc">CC-BY-4.0</span></td></tr>
-      <tr><td><div class="dn"><a href="https://huggingface.co/datasets/facebook/belebele" rel="noopener">Belebele (PL)</a></div><div class="ds">reading comprehension</div></td><td>rozumienie</td><td>accuracy MCQ</td><td>900</td><td><span class="chip acc">CC-BY-SA</span></td></tr>
+      <tr><td><div class="dn"><a href="https://huggingface.co/datasets/clarin-pl/poquad" rel="noopener">PoQuAD</a></div><div class="ds">SQuAD 2.0, natywnie PL, no-answer</div></td><td>zakotwiczenie / odmowa</td><td>F1 + sędzia-LLM</td><td>~52 000</td><td><span class="chip acc">CC-BY-4.0</span></td></tr>
+      <tr><td><div class="dn"><a href="https://huggingface.co/datasets/facebook/belebele" rel="noopener">Belebele (PL)</a></div><div class="ds">rozumienie tekstu</div></td><td>rozumienie</td><td>accuracy MCQ</td><td>900</td><td><span class="chip acc">CC-BY-SA</span></td></tr>
       <tr><td><div class="dn"><a href="https://huggingface.co/datasets/CohereForAI/include-base-44" rel="noopener">INCLUDE-44 (PL)</a></div><div class="ds">wiedza kulturowo-regionalna</div></td><td>wiedza PL</td><td>accuracy MCQ</td><td>config PL</td><td><span class="chip acc">publiczny</span></td></tr>
       <tr><td><div class="dn"><a href="https://huggingface.co/datasets/openlanguagedata/flores_plus" rel="noopener">FLORES-200 (PL)</a></div><div class="ds">tłumaczenie PL↔</div></td><td>regresja generacji</td><td>BLEU / chrF</td><td>1 012</td><td><span class="chip blue">gated · dostęp</span></td></tr>
     </tbody></table></div>
@@ -49,7 +49,7 @@
       <tr><td><div class="dn">ISAP / akty prawne</div><div class="ds">ustawy, rozporządzenia</div></td><td>grounded QA, wiedza prawna</td><td><span class="chip">do zebrania</span></td></tr>
       <tr><td><div class="dn">Orzeczenia (SAOS)</div><div class="ds">baza orzeczeń sądów</div></td><td>rozumowanie prawne</td><td><span class="chip">do zebrania</span></td></tr>
       <tr><td><div class="dn">Interpretacje (KIS/MF)</div><div class="ds">podatki, objaśnienia</div></td><td>wariant podatkowy</td><td><span class="chip">do zebrania</span></td></tr>
-      <tr><td><div class="dn">Instrukcje PL (SFT)</div><div class="ds">kurowane + syntetyczne</div></td><td>instruction tuning</td><td><span class="chip">do budowy</span></td></tr>
+      <tr><td><div class="dn">Instrukcje PL (SFT)</div><div class="ds">kurowane + syntetyczne</div></td><td>dostrajanie instrukcyjne</td><td><span class="chip">do budowy</span></td></tr>
       <tr><td><div class="dn">Pary preferencji (DPO)</div><div class="ds">lepsza/gorsza odpowiedź</div></td><td>alignment</td><td><span class="chip">do budowy</span></td></tr>
       <tr><td><div class="dn">Prywatny held-out</div><div class="ds">najnowsze egzaminy CKE/PES</div></td><td>wykrywanie benchmaxxingu</td><td><span class="chip">do budowy</span></td></tr>
     </tbody></table></div>

--- a/eksperymenty.html
+++ b/eksperymenty.html
@@ -63,7 +63,7 @@
       <div class="banner">
         <b>Uczciwa zasada:</b> każdy model jest tu z pełnym składem danych i wynikiem. Trening na train-splicie
         benchmarku oznaczamy <b style="color:#c98a78">KONTAMINACJA</b> — bo zawyża wynik i jest nieporównywalny
-        z modelami liczonymi 5-shot. Realny claim robimy wyłącznie na <b>oficjalnym 5-shot leaderboardzie + MT-Bench-PL</b>.
+        z modelami liczonymi 5-shot. Realne twierdzenie stawiamy wyłącznie na <b>oficjalnym 5-shot leaderboardzie + MT-Bench-PL</b>.
       </div>
 
       <div class="log" id="log"><div class="muted mono" style="margin-top:20px">wczytuję log…</div></div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
       <div class="inner">
         <div class="stat"><div class="v" id="st-bench">10</div><div class="k">osi ewaluacji</div></div>
         <div class="stat"><div class="v">24<span class="ac">k</span></div><div class="k">rekordów z widocznym rodowodem</div></div>
-        <div class="stat"><div class="v">100<span class="ac">%</span></div><div class="k">claimów z held-out</div></div>
+        <div class="stat"><div class="v">100<span class="ac">%</span></div><div class="k">twierdzeń z held-out</div></div>
         <div class="stat"><div class="v">~18<span class="ac">k zł</span></div><div class="k">koszt wpisany w wynik</div></div>
       </div>
     </div>
@@ -117,12 +117,12 @@
           </a>
           <a class="logrow" href="/datasety">
             <span class="dt">2026-06</span>
-            <span class="what"><b>datasets</b>: dane treningowe + karty + lineage<span class="sub">miksy 1:1, disclosure kontaminacji v2</span></span>
+            <span class="what"><b>datasety</b>: dane treningowe + karty + lineage<span class="sub">miksy 1:1, disclosure kontaminacji v2</span></span>
             <span class="go">ślady →</span>
           </a>
           <a class="logrow" href="/benchmarks">
             <span class="dt">2026-06</span>
-            <span class="what"><b>benchmarks</b>: karty 10 osi pomiaru<span class="sub">metryki, train policy, znane pułapki</span></span>
+            <span class="what"><b>benchmarki</b>: karty 10 osi pomiaru<span class="sub">metryki, train policy, znane pułapki</span></span>
             <span class="go">osie →</span>
           </a>
           <a class="logrow" href="https://arena.fabryka.ai" rel="noopener" target="_blank">
@@ -152,7 +152,7 @@
         <a class="cell area" href="/trening"><div class="top"><span>trening</span><span class="ar">→</span></div>
           <h3>Recepty, które przechodzą próg</h3>
           <p>QLoRA SFT, preferencje (DPO/ORPO), RL na weryfikowalnych nagrodach. Każdy run z gate'ami regresji: zysk na celu bez utraty kompetencji bazowych.</p>
-          <div class="meta"><div><span class="k">artefakt</span>cooking recipe + training log + decyzje z pomiarów</div></div></a>
+          <div class="meta"><div><span class="k">artefakt</span>przepis treningowy + dziennik treningu + decyzje z pomiarów</div></div></a>
         <a class="cell area" href="/kierunki"><div class="top"><span>styl</span><span class="ar">→</span></div>
           <h3>Naturalna polszczyzna</h3>
           <p>Model ma pisać jak ktoś, kto ma ucho: bez kalek z angielskiego, bez asystenckiej waty, z natywną fleksją. Mierzone twardymi metrykami i otwartym sędzią.</p>
@@ -211,7 +211,7 @@
     <div class="inner narrow" style="text-align:center">
       <span class="kick">dołącz</span>
       <h2 class="serif" style="font-size:clamp(2.1rem,4.2vw,3.1rem);font-weight:400;letter-spacing:-.015em;margin:14px 0 14px">Wejdź, jeśli chcesz mierzyć.</h2>
-      <p class="muted" style="max-width:54ch;margin:0 auto 26px;font-size:1.06rem">Kontrybutorzy, naukowcy, firmy z use case'ami i fundatorzy compute. Publiczny zapis, od razu widać, kto już jest.</p>
+      <p class="muted" style="max-width:54ch;margin:0 auto 26px;font-size:1.06rem">Kontrybutorzy, naukowcy, firmy z zastosowaniami i fundatorzy mocy obliczeniowej. Publiczny zapis, od razu widać, kto już jest.</p>
       <div class="cta-row" style="justify-content:center"><a class="btn btn-p" href="https://discord.gg/HnTkVR4c5T" rel="noopener" target="_blank">wejście do labu →</a><a class="btn btn-s" href="/zespol">zapisz się</a></div>
     </div>
   </section>

--- a/kierunki.html
+++ b/kierunki.html
@@ -30,7 +30,7 @@
     <div class="ghead"><h2>Zdolności horyzontalne</h2><span class="c">przekrojowe · moat niższy</span></div>
     <div class="grid auto-lg">
       <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">Agentowy / tool-use</h3><p>Function calling, planowanie, orkiestracja, RAG po polsku.</p><div class="meta"><div><span class="k">eval</span> tool-use + instrukcyjność</div></div></div>
-      <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">RAG / enterprise</h3><p>Odpowiedzi z firmowych dokumentów z cytatem, on-prem.</p><div class="meta"><div><span class="k">eval</span> reading comp. + faithfulness</div></div></div>
+      <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">RAG / enterprise</h3><p>Odpowiedzi z firmowych dokumentów z cytatem, on-prem.</p><div class="meta"><div><span class="k">eval</span> rozumienie tekstu + faithfulness</div></div></div>
       <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">Tłumaczeniowy PL↔</h3><p>Tłumaczenia wysokiej jakości — oś, gdzie polskie modele są mocne.</p><div class="meta"><div><span class="k">eval</span> FLORES-200 (BLEU/chrF)</div></div></div>
       <div class="cell"><div class="top"><span class="moat l">moat niski</span></div><h3 class="sm">Coding po polsku</h3><p>Asystent dev z polskim kontekstem, code review, docs.</p><div class="meta"><div><span class="k">eval</span> code + EN regresja</div></div></div>
     </div>
@@ -38,7 +38,7 @@
     <div class="grid auto-lg">
       <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">Flagowy ogólny PL</h3><p>Naturalny styl, idiomy, rejestry, wiedza kulturowa.</p><div class="meta"><div><span class="k">eval</span> Open PL LLM (agregat)</div></div></div>
       <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">Edukacyjny</h3><p>Korepetytor pod podstawę programową, matura, ósmoklasista.</p><div class="meta"><div><span class="k">eval</span> QA przedmiotowe + reasoning</div></div></div>
-      <div class="cell"><div class="top"><span class="moat l">moat niski</span></div><h3 class="sm">Obsługa klienta</h3><p>Contact center: ton, deeskalacja, polityki firmowe.</p><div class="meta"><div><span class="k">eval</span> instrukcyjność + ton</div></div></div>
+      <div class="cell"><div class="top"><span class="moat l">moat niski</span></div><h3 class="sm">Obsługa klienta</h3><p>Centrum obsługi: ton, deeskalacja, polityki firmowe.</p><div class="meta"><div><span class="k">eval</span> instrukcyjność + ton</div></div></div>
       <div class="cell"><div class="top"><span class="moat m">moat średni</span></div><h3 class="sm">Guard / moderacja</h3><p>Mały model-strażnik: moderacja, ryzyka, bezpieczeństwo po polsku.</p><div class="meta"><div><span class="k">eval</span> klasyfikacja (P/R)</div></div></div>
     </div>
     <div class="note"><p><b>Jak wybieramy:</b> najlepszy stosunek moatu danych do kosztu w budżecie 15–20k zł. Masz pomysł albo use case? <a href="/zespol" style="color:var(--acc);font-weight:500">Dołącz / zgłoś →</a></p></div>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -26,13 +26,13 @@
     <div class="inner">
       <div class="top">
         <div><span class="kick"><span class="ac">LEADERBOARD</span> — bielik vs qwen3.5-9b</span><h1>Wyniki na żywo</h1></div>
-        <span class="live"><span class="d"></span>LIVE · AUTO-SYNC</span>
+        <span class="live"><span class="d"></span>NA ŻYWO · AUTO-SYNC</span>
       </div>
       <p class="upd" id="updated">wczytuję…</p>
       <div class="board">
         <div class="team"><div class="tg">punkt odniesienia</div><div class="nm">Bielik-11B-v3</div></div>
         <div class="cnt"><span class="b" id="sb">0</span><span class="d">:</span><span class="q" id="sq">0</span></div>
-        <div class="team"><div class="tg">challenger</div><div class="nm">Qwen3.5-9B</div></div>
+        <div class="team"><div class="tg">pretendent</div><div class="nm">Qwen3.5-9B</div></div>
         <div class="bfoot" id="bfoot">—</div>
       </div>
       <div id="content"></div>

--- a/propozycja.html
+++ b/propozycja.html
@@ -33,7 +33,7 @@
   <div id="site-nav"></div>
   <div class="sec page-top">
     <div class="inner">
-      <span class="status-pill"><span class="d" style="width:7px;height:7px;border-radius:50%;background:var(--acc);display:inline-block"></span>CURRENT PROTOCOL · otwarte na feedback</span>
+      <span class="status-pill"><span class="d" style="width:7px;height:7px;border-radius:50%;background:var(--acc);display:inline-block"></span>BIEŻĄCY PROTOKÓŁ · otwarte na uwagi</span>
       <h1>Protokół <em style="font-style:italic;color:var(--acc)">v3</em> — czysty model, realna dźwignia</h1>
       <p class="lead" style="max-width:680px;margin-top:14px">Chcemy model, który <b>wychodzi dobrze na KLEJ bez trenowania na jego train/test</b> — tylko na tym, co się <b>generalizuje</b>. To jest mapa przed runem: hipoteza, dane, koszt, gate publikacji.</p>
 
@@ -54,7 +54,7 @@
         </div>
 
         <div class="block" style="border-color:rgba(199,148,72,.3);background:var(--acc-soft)">
-          <span class="kick">feedback od społeczności · wbudowany</span>
+          <span class="kick">głos społeczności · wbudowany</span>
           <h2>„Bez pretreningu nie dodasz mu wiedzy (np. o Polsce)"</h2>
           <p class="lead"><b>Słuszne.</b> SFT uczy <i>umiejętności</i> i wydobywa to, co model już wie — <b>nie dodaje nowej wiedzy</b>. Wiedza powstaje w pretreningu. Dodatkowo: <b>cienki DoRA (low-rank) i tak nie pomieści wiedzy</b>. Dlatego rozdzielamy fazy i dorzucamy realny <b>CPT</b>:</p>
           <table>
@@ -75,9 +75,9 @@
           <p class="lead">Z budżetem na CPT pytanie brzmi nie „czy", tylko „<b>ile</b>". A tego nie zmierzysz Open PL LLM Leaderboardem — on <b>nie mierzy długiego ogona</b> (lokalne realia, prawo, regionalia, idiomy). Dlatego <b>przed treningiem</b> budujemy własny eval wiedzy o Polsce:</p>
           <div class="two">
             <div class="mini"><h3>co</h3><p>Sonda wiedzy długiego ogona PL: historia, prawo/orzecznictwo, geografia, regionalia, idiomy, kultura, współczesność. Każde pytanie z <b>weryfikowalną</b> odpowiedzią. Held-out, deduplikowane, NIE wchodzi do CPT.</p></div>
-            <div class="mini"><h3>po co</h3><p>Baseline <b>Qwen3.5-27B vs Bielik</b> per domena → mapa luk → <b>wymiaruje CPT</b> (10B czy 40B tokenów, które domeny). Bez tego nie wiesz, czy CPT cokolwiek dał.</p></div>
+            <div class="mini"><h3>po co</h3><p>Punkt odniesienia <b>Qwen3.5-27B vs Bielik</b> per domenę → mapa luk → <b>wymiaruje CPT</b> (10B czy 40B tokenów, które domeny). Bez tego nie wiesz, czy CPT cokolwiek dał.</p></div>
           </div>
-          <p class="lead" style="font-size:.9rem;margin-top:10px">To też publiczny <b>asset</b> — dowód, że pobiliśmy Bielika tam, gdzie miał być najmocniejszy (pasuje do CodeSOTA/leaderboardów wiedzy).</p>
+          <p class="lead" style="font-size:.9rem;margin-top:10px">To też publiczny <b>zasób</b> — dowód, że pobiliśmy Bielika tam, gdzie miał być najmocniejszy (pasuje do CodeSOTA/leaderboardów wiedzy).</p>
         </div>
 
         <div class="block">
@@ -144,12 +144,12 @@
 
         <div class="ctaband">
           <h2>Masz zdanie? Zanim to zbudujemy — powiedz.</h2>
-          <p>To protokół badawczy przed runem. Dataset v3 powstaje publicznie i chcemy go poprawić z waszym feedbackiem.</p>
-          <a class="btn btn-p" href="https://discord.gg/HnTkVR4c5T" rel="noopener" target="_blank">wejdź z feedbackiem →</a>
+          <p>To protokół badawczy przed runem. Dataset v3 powstaje publicznie i chcemy go poprawić z waszymi uwagami.</p>
+          <a class="btn btn-p" href="https://discord.gg/HnTkVR4c5T" rel="noopener" target="_blank">podziel się uwagami →</a>
         </div>
 
       </div>
-      <p class="muted mono" style="text-align:center;font-size:.76rem;margin-top:22px">propozycja otwarta · źródło: <a href="https://github.com/slayerlabs" rel="noopener">GitHub</a> · zmienia się z waszym feedbackiem</p>
+      <p class="muted mono" style="text-align:center;font-size:.76rem;margin-top:22px">propozycja otwarta · źródło: <a href="https://github.com/slayerlabs" rel="noopener">GitHub</a> · zmienia się z waszymi uwagami</p>
     </div>
   </div>
   <div id="site-foot"></div>

--- a/roadmap.html
+++ b/roadmap.html
@@ -11,15 +11,15 @@
   <div id="site-nav"></div>
   <section class="phero"><div class="inner">
     <span class="kick">harmonogram · 6–8 tygodni</span>
-    <h1>Plan i <em>call for contributions</em></h1>
-    <p>Od pomiaru baseline, przez dane i pierwszy trening, po RL na egzaminach. Wszystko jawne, odtwarzalne, mierzone na held-out. Daty orientacyjne — projekt idzie tak szybko, jak społeczność.</p>
+    <h1>Plan i <em>zaproszenie do współpracy</em></h1>
+    <p>Od pomiaru bazowego, przez dane i pierwszy trening, po RL na egzaminach. Wszystko jawne, odtwarzalne, mierzone na held-out. Daty orientacyjne — projekt idzie tak szybko, jak społeczność.</p>
   </div></section>
 
   <section class="sec tight"><div class="inner">
     <div class="note" style="margin:0 0 28px;border-left-color:var(--acc)"><p><b>Decyzja (wg leaderboardu):</b> <b style="color:var(--ink)">baza = Qwen3.5-9B</b>. W pomiarze Fazy 0 Qwen3.5-9B bije Bielika-11B-v3 8:1 (9 ważnych osi), w tym na większości polskich. Bielik trzyma jedynie <b style="color:var(--ink)">LLMzSzŁ</b> (egzaminy państwowe/zawodowe) — naszą oś docelową. Plan: Qwen jako baza + polska specjalizacja celowana w LLMzSzŁ i prawo/administrację → przebić Bielika szeroko. <a href="/leaderboard" style="color:var(--acc)">wyniki →</a></p></div>
     <div class="ghead"><h2>Harmonogram</h2><span class="c">zakończone · następne · planowane</span></div>
     <div class="tl">
-      <div class="ph"><div><div class="when">F0 · czerwiec</div><span class="st" style="color:var(--acc);background:var(--acc-soft);border:1px solid rgba(199,148,72,.3)">zakończona ✓</span></div><div><h3>Pomiar baseline</h3><p>Bielik 1 : 8 Qwen3.5-9B (9 ważnych osi, multi-seed). Werdykt: baza = Qwen3.5-9B. <a href="/leaderboard" style="color:var(--acc)">leaderboard</a>.</p></div></div>
+      <div class="ph"><div><div class="when">F0 · czerwiec</div><span class="st" style="color:var(--acc);background:var(--acc-soft);border:1px solid rgba(199,148,72,.3)">zakończona ✓</span></div><div><h3>Pomiar bazowy</h3><p>Bielik 1 : 8 Qwen3.5-9B (9 ważnych osi, multi-seed). Werdykt: baza = Qwen3.5-9B. <a href="/leaderboard" style="color:var(--acc)">leaderboard</a>.</p></div></div>
       <div class="ph"><div><div class="when">F1 · czerwiec</div><span class="st" style="color:var(--acc);background:var(--acc-soft);border:1px solid rgba(199,148,72,.3)">w toku</span></div><div><h3>Społeczność i dane</h3><p><a href="https://github.com/slayerlabs" style="color:var(--acc)">Repo</a> otwarte, zespół (<a href="/zespol" style="color:var(--acc)">zapisy</a>), korpusy prawno-urzędowe (<a href="/datasety" style="color:var(--acc)">datasety</a>), dekontaminacja, held-out.</p></div></div>
       <div class="ph"><div><div class="when">F2 · lipiec</div><span class="st" style="color:var(--dim);background:var(--panel2);border:1px solid var(--line2)">planowane</span></div><div><h3>Pierwszy trening</h3><p>QLoRA SFT na <b>Qwen3.5-9B</b> (PL + egzaminy zawodowe) → ORPO/DPO. <a href="/trening" style="color:var(--acc)">metody</a>.</p></div></div>
       <div class="ph"><div><div class="when">F3 · lipiec/sierpień</div><span class="st" style="color:var(--dim);background:var(--panel2);border:1px solid var(--line2)">planowane</span></div><div><h3>RL na egzaminach</h3><p>GRPO/RLVR z weryfikowalną nagrodą + trening odmowy/grounding.</p></div></div>
@@ -29,12 +29,12 @@
   </div></section>
 
   <section class="sec tight alt"><div class="inner">
-    <div class="ghead"><h2>Call for contributions</h2><span class="c">czego potrzebujemy teraz (F0→F1)</span></div>
+    <div class="ghead"><h2>Zaproszenie do współpracy</h2><span class="c">czego potrzebujemy teraz (F0→F1)</span></div>
     <div class="grid auto-lg">
-      <div class="cell"><div class="n">RĘCE</div><h3 class="sm">Kontrybutorzy</h3><p>Evale, dekontaminacja, loadery, dane. Wejdź na dowolnym poziomie.</p><div class="meta"><a href="/zadania" style="color:var(--acc)">Lista zadań →</a></div></div>
+      <div class="cell"><div class="n">RĘCE</div><h3 class="sm">Kontrybutorzy</h3><p>Ewaluacje, dekontaminacja, loadery, dane. Wejdź na dowolnym poziomie.</p><div class="meta"><a href="/zadania" style="color:var(--acc)">Lista zadań →</a></div></div>
       <div class="cell"><div class="n">DANE</div><h3 class="sm">Dane prawno-urzędowe</h3><p>ISAP, orzeczenia, interpretacje — to nasz moat.</p><div class="meta"><a href="/datasety" style="color:var(--acc)">Datasety →</a></div></div>
-      <div class="cell"><div class="n">RYNEK</div><h3 class="sm">Firmy — use case</h3><p>Powiedz, czego potrzebujesz. Zostań early adopterem.</p><div class="meta"><a href="/zespol" style="color:var(--acc)">Zgłoś use case →</a></div></div>
-      <div class="cell"><div class="n">COMPUTE</div><h3 class="sm">Fundatorzy</h3><p>GPU lub kredyty (RunPod/Vast). Budżet 15–20k zł, każda złotówka jawna.</p><div class="meta"><a href="/zespol" style="color:var(--acc)">Wesprzyj →</a></div></div>
+      <div class="cell"><div class="n">RYNEK</div><h3 class="sm">Firmy — zastosowanie</h3><p>Powiedz, czego potrzebujesz. Zostań pierwszym użytkownikiem.</p><div class="meta"><a href="/zespol" style="color:var(--acc)">Zgłoś use case →</a></div></div>
+      <div class="cell"><div class="n">ZASOBY</div><h3 class="sm">Fundatorzy</h3><p>GPU lub kredyty (RunPod/Vast). Budżet 15–20k zł, każda złotówka jawna.</p><div class="meta"><a href="/zespol" style="color:var(--acc)">Wesprzyj →</a></div></div>
       <div class="cell"><div class="n">NAUKA</div><h3 class="sm">Naukowcy</h3><p>Metodyka, ewaluacje, współautorstwo wyników.</p><div class="meta"><a href="/zespol" style="color:var(--acc)">Dołącz →</a></div></div>
     </div>
     <div class="cta-row" style="margin-top:24px"><a class="btn btn-p" href="/zespol">Dołącz / zapisz się →</a><a class="btn btn-s" href="https://discord.gg/HnTkVR4c5T" rel="noopener">Discord</a></div>

--- a/rules.html
+++ b/rules.html
@@ -26,7 +26,7 @@
   <div id="site-nav"></div>
 
   <section class="phero"><div class="inner">
-    <span class="kick">rules · governance · autorstwo</span>
+    <span class="kick">zasady · zarządzanie · autorstwo</span>
     <h1>Zasady <em>projektu</em></h1>
     <p>Slayer zaczyna jako otwarty warsztat badawczy: publikujemy metody, pomiary i część artefaktów tak, by społeczność mogła je weryfikować i rozwijać. Otwartość dotyczy standardu pracy badawczej, nie deklaracji nonprofit. Slayer może w przyszłości działać jako organizacja komercyjna, jeśli będzie to najlepszy sposób finansowania compute, utrzymania zespołu i wdrażania polskich modeli w praktyce.</p>
   </div></section>
@@ -52,7 +52,7 @@
     <div class="rulelist">
       <div class="ruleitem"><div class="no">01</div><div><h3>Jedna oficjalna linia</h3><p>Każdy może eksperymentować, forkować i proponować zmiany. Oficjalny Slayer zachowuje jednak jedną linię decyzyjną i jedną odpowiedzialność redakcyjną.</p></div></div>
       <div class="ruleitem"><div class="no">02</div><div><h3>Merit, nie hałas</h3><p>Decyzje techniczne zapadają na podstawie artefaktów: kodu, danych, pomiarów, kosztu, replikowalności i jakości odpowiedzi. Sama opinia nie wystarcza.</p></div></div>
-      <div class="ruleitem"><div class="no">03</div><div><h3>Wkład daje głos</h3><p>Realni kontrybutorzy mają wpływ na roadmapę i priorytety. Wpływ rośnie z odpowiedzialnością za dowożone rzeczy, a nie z deklaracjami.</p></div></div>
+      <div class="ruleitem"><div class="no">03</div><div><h3>Wkład daje głos</h3><p>Realni kontrybutorzy mają wpływ na plan działania i priorytety. Wpływ rośnie z odpowiedzialnością za dowożone rzeczy, a nie z deklaracjami.</p></div></div>
       <div class="ruleitem"><div class="no">04</div><div><h3>Spory domykamy</h3><p>Jeśli dyskusja nie prowadzi do decyzji, BDFL domyka temat. Celem jest ruch projektu, nie nieskończona debata.</p></div></div>
       <div class="ruleitem"><div class="no">05</div><div><h3>Governance może dorosnąć</h3><p>Gdy projekt będzie miał stabilnych maintainerów, regularnych kontrybutorów i większą powierzchnię odpowiedzialności, struktura może przejść w bardziej formalny model. Do tego czasu obowiązuje BDFL.</p></div></div>
     </div>

--- a/team.html
+++ b/team.html
@@ -171,8 +171,8 @@
           <div class="member-info">
             <div class="member-title-label">Member of Technical Staff</div>
             <h2 class="member-name">Piotr Nalepa</h2>
-            <div class="member-specialty">Fullstack · Narzędzia developerskie</div>
-            <p class="member-bio">Fullstack, zarządzanie projektem i tworzenie narzędzi dla developerów.</p>
+            <div class="member-specialty">Fullstack · Narzędzia deweloperskie</div>
+            <p class="member-bio">Fullstack, zarządzanie projektem i tworzenie narzędzi dla deweloperów.</p>
           </div>
         </article>
 
@@ -212,7 +212,7 @@
           <div class="member-info">
             <div class="member-title-label">Member of Technical Staff</div>
             <h2 class="member-name" style="color:var(--dim)">Twoje imię tutaj</h2>
-            <div class="member-specialty">Twój stack · Twoja domena</div>
+            <div class="member-specialty">Twoje technologie · Twoja domena</div>
             <p class="member-bio"><a href="https://discord.gg/HnTkVR4c5T" target="_blank" rel="noopener" style="color:var(--acc)">Dołącz do zespołu →</a></p>
           </div>
         </article>
@@ -223,7 +223,7 @@
       <div class="join-cta">
         <div>
           <h2>Wejście do warsztatu</h2>
-          <p>Szukamy ludzi, którzy potrafią domykać artefakty: kod, dane, evale, infra, dokumentację. Governance projektu opisują <a href="/rules" style="color:var(--acc)">rules</a>.</p>
+          <p>Szukamy ludzi, którzy potrafią domykać artefakty: kod, dane, ewaluacje, infra, dokumentację. Zasady projektu opisuje <a href="/rules" style="color:var(--acc)">regulamin</a>.</p>
         </div>
         <a class="btn btn-p" href="https://discord.gg/HnTkVR4c5T" target="_blank" rel="noopener">wejście przez Discord →</a>
       </div>

--- a/trening.html
+++ b/trening.html
@@ -56,13 +56,13 @@
     <div class="grid auto"><div class="cell"><div class="top"><span>QLoRA / LoRA</span><span class="ct">rekom.</span></div><p>4-bit + adaptery → 11–14B na jednym GPU.</p></div>
       <div class="cell"><div class="top"><span>DoRA / LoRA+</span><span class="ct y">zaawans.</span></div><p>Bliżej full-FT przy podobnym koszcie.</p></div>
       <div class="cell"><div class="top"><span>Unsloth / Liger</span><span class="ct b">tanie</span></div><p>2–4× szybciej, mniej VRAM.</p></div>
-      <div class="cell"><div class="top"><span>NEFTune + packing</span><span class="ct b">tanie</span></div><p>Darmowy zysk jakości i throughputu.</p></div></div>
+      <div class="cell"><div class="top"><span>NEFTune + packing</span><span class="ct b">tanie</span></div><p>Darmowy zysk jakości i przepustowości.</p></div></div>
     <div class="ghead"><h2>3 · Preferencje</h2><span class="c">offline, bez ciężkiego RLHF</span></div>
     <div class="grid auto"><div class="cell"><div class="top"><span>DPO</span><span class="ct">sprawdzone</span></div><p>Pary lepsza/gorsza, stabilne, bez modelu nagrody.</p></div>
       <div class="cell"><div class="top"><span>ORPO</span><span class="ct">1 etap</span></div><p>SFT + preferencje naraz, bez modelu ref.</p></div>
       <div class="cell"><div class="top"><span>SimPO / KTO</span><span class="ct b">tańsze</span></div><p>Ref-free / bez par — łatwiej o dane.</p></div>
       <div class="cell"><div class="top"><span>iterative DPO</span><span class="ct y">zaawans.</span></div><p>Generuj → oceń (RLAIF) → dotrenuj, w pętli.</p></div></div>
-    <div class="ghead"><h2>4 · RL na weryfikowalnych nagrodach</h2><span class="c">killer pod egzaminy</span></div>
+    <div class="ghead"><h2>4 · RL na weryfikowalnych nagrodach</h2><span class="c">przełom pod egzaminy</span></div>
     <div class="grid auto"><div class="cell"><div class="top"><span>GRPO</span><span class="ct">pod egzaminy</span></div><p>RL bez modelu wartości. Nagroda = poprawna litera.</p></div>
       <div class="cell"><div class="top"><span>RLVR</span><span class="ct">pod target</span></div><p>Egzaminy mają klucz → tania, mocna nagroda.</p></div>
       <div class="cell"><div class="top"><span>distylacja CoT</span><span class="ct b">tanie</span></div><p>Łańcuchy myślenia z mocnego nauczyciela.</p></div></div>

--- a/zespol.html
+++ b/zespol.html
@@ -27,7 +27,7 @@
   <section class="phero"><div class="inner">
     <span class="kick">dołącz · publiczny zapis</span>
     <h1>Zbuduj z nami <em>polski model</em></h1>
-    <p>Wpisz się — od razu widać, kto już jest i co oferuje. Kontrybutorzy, naukowcy, fundatorzy compute i firmy (zgłoście use case). Kontakt zostaje prywatny; publicznie widać imię, rolę i opis.</p>
+    <p>Wpisz się — od razu widać, kto już jest i co oferuje. Kontrybutorzy, naukowcy, fundatorzy mocy obliczeniowej i firmy (zgłoście zastosowanie). Kontakt zostaje prywatny; publicznie widać imię, rolę i opis.</p>
   </div></section>
 
   <section class="sec tight"><div class="inner">
@@ -35,7 +35,7 @@
     <div class="aud">
       <div class="cell ac"><div class="n">RĘCE</div><h3 class="sm">Kontrybutorzy</h3><p>Kod, dane, ewaluacje, infra. Start od <a href="/zadania" style="color:var(--acc)">zadań</a>.</p><button data-role="Kontrybutor">Zapisz się →</button></div>
       <div class="cell ac"><div class="n">NAUKA</div><h3 class="sm">Naukowcy</h3><p>Metodyka, ewaluacje, współautorstwo.</p><button data-role="Naukowiec/badania">Zapisz się →</button></div>
-      <div class="cell ac"><div class="n">RYNEK</div><h3 class="sm">Firmy</h3><p>Zgłoś use case (prawo, urzędy, branża), zostań early adopterem.</p><button data-role="Firma/use-case">Zgłoś use case →</button></div>
+      <div class="cell ac"><div class="n">RYNEK</div><h3 class="sm">Firmy</h3><p>Zgłoś zastosowanie (prawo, urzędy, branża), zostań wczesnym użytkownikiem.</p><button data-role="Firma/use-case">Zgłoś zastosowanie →</button></div>
       <div class="cell ac"><div class="n">COMPUTE</div><h3 class="sm">Fundatorzy</h3><p>Sfinansuj GPU (15–20k zł) albo daj kredyty.</p><button data-role="Fundator/compute">Wesprzyj →</button></div>
     </div>
   </div></section>
@@ -54,11 +54,11 @@
             <label><input type="checkbox" name="role" value="Trening/ML"> Trening / ML</label>
             <label><input type="checkbox" name="role" value="Infra/DevOps"> Infra</label>
             <label><input type="checkbox" name="role" value="Naukowiec/badania"> Naukowiec</label>
-            <label><input type="checkbox" name="role" value="Firma/use-case"> Firma / use-case</label>
+            <label><input type="checkbox" name="role" value="Firma/use-case"> Firma / zastosowanie</label>
             <label><input type="checkbox" name="role" value="Fundator/compute"> Fundator / compute</label>
           </div></div>
         <div class="field"><label for="contact">Kontakt <span class="opt">(Discord / e-mail / GitHub — prywatny)</span></label><input type="text" id="contact" maxlength="120" required placeholder="np. discord: kasia#1234"></div>
-        <div class="field"><label for="about">Co oferujesz / use case <span class="opt">(opcjonalnie, publiczne)</span></label><textarea id="about" maxlength="400" placeholder="np. robię evale w lm-eval-harness; albo: firma prawnicza, use case: analiza umów"></textarea></div>
+        <div class="field"><label for="about">Co oferujesz / zastosowanie <span class="opt">(opcjonalnie, publiczne)</span></label><textarea id="about" maxlength="400" placeholder="np. robię evale w lm-eval-harness; albo: firma prawnicza, use case: analiza umów"></textarea></div>
         <button class="btn btn-p" type="submit" id="submit">Dołącz publicznie</button>
         <div class="msg" id="msg"></div>
         <p class="muted" style="font-size:.84rem;margin:0">Publicznie pokażemy imię, role i opis. Kontakt trafia tylko do organizatora.</p>


### PR DESCRIPTION
Zastąpiono powszechnie tłumaczalne anglicyzmy polskimi odpowiednikami:

call for contributions → zaproszenie do współpracy,
use case → zastosowanie,
early adopter → wczesny użytkownik,
compute → moc obliczeniowa,
challenger → pretendent,
claim → twierdzenie,
feedback → uwagi,
asset → zasób,
baseline → pomiar bazowy / punkt odniesienia,
throughput → przepustowość i inne.

Terminologia techniczna ML (benchmark, fine-tuning, held-out, pipeline itp.) pozostała bez zmian jako świadome wyjątki.