### PR TITLE
fix(include): popraw mapowanie gold w loaderze INCLUDE-44

### DIFF
--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from huggingface_hub import hf_hub_download, HfApi
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
-OUT = "/home/kacper/bench_results"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 MODELS = [
     ("Bielik-11B-v3.0-Instruct", "hf.co/speakleash/Bielik-11B-v3.0-Instruct-GGUF:Q4_K_M"),
     ("Qwen3.5-9B",               "qwen3.5:9b"),
@@ -72,7 +72,7 @@ def load_include(n, seed):
     for r in ds:
         opts = [r["option_a"], r["option_b"], r["option_c"], r["option_d"]]
         a = str(r["answer"]).strip()
-        gold = "abcdABCD".find(a) % 4 if a and a[0].lower() in "abcd" else int(a) - 1  # INCLUDE: 1-based int
+        gold = "abcdABCD".find(a) % 4 if a and a[0].lower() in "abcd" else int(a)  # 0-based int
         if 0 <= gold < 4:
             items.append({"q": r["question"], "options": opts, "gold": gold, "cat": r.get("domain", "?")})
     return sample_strat(items, n, seed)

--- a/bench/make_dashboard.py
+++ b/bench/make_dashboard.py
@@ -20,8 +20,6 @@ def load():
         try:
             p = json.load(open(f, encoding="utf-8"))
             if isinstance(p, dict) and "benchmark" in p and "models" in p:
-                if p.get("benchmark") == "include":  # loader gold-mapping broken (below random) — excluded until fixed
-                    continue
                 out.append(p)
         except Exception: pass
     return out


### PR DESCRIPTION
Closes #1. 

Dataset używa indeksowania 0-based, kod zakładał 1-based. 

Skutek: 149/548 wierszy pomijanych (answer=0 → gold=-1), pozostałe z gold przesuniętym o 1. Accuracy poniżej losowego. 

Poprawka: int(a) zamiast int(a)-1. 

Weryfikacja: 0/548 poza zakresem, pilotaż n=50 → Bielik 70%, Qwen 64%.

Bonus: OUT z env BENCH_OUT zamiast hardcodowanego. 