### PR TITLE
[codex] add Chomsky SOTA2026 tokenizer artifacts

### DIFF
--- a/bench/chomsky_sota2026/README.md
+++ b/bench/chomsky_sota2026/README.md
@@ -1,0 +1,30 @@
+# Chomsky SOTA 2026 Tokenizer Smoke
+
+Engineering artifact copied from the Chomsky tokenizer prototype.
+
+## Run
+
+From this directory:
+
+```bash
+python3 scripts/generate_synthetic_morph_examples.py --count 100
+python3 scripts/run_morph_bpe.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
+python3 scripts/run_downstream_smoke.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
+python3 scripts/run_neural_segmenter.py --epochs 200 --train data/morph_benchmark.json data/synthetic_morph_examples.json
+```
+
+If `morfeusz2` is installed, also run:
+
+```bash
+python3 scripts/evaluate_morph_segmentation.py
+```
+
+## Static Artifacts
+
+Published dashboard data is mirrored under:
+
+```text
+public/data/chomsky-sota2026/
+```
+
+Synthetic examples are marked with `verified=false`; they are stress data, not manually verified gold.

--- a/bench/chomsky_sota2026/data/morph_benchmark.json
+++ b/bench/chomsky_sota2026/data/morph_benchmark.json
@@ -1,0 +1,91 @@
+{
+  "name": "Polish Morphological Boundary Benchmark",
+  "version": "0.1.0",
+  "description": "Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.",
+  "cases": [
+    {
+      "id": "adv_comp_bardziej",
+      "category": "adverb_comparative",
+      "surface": "bardziej",
+      "expected_morph_tags": ["adv:com"],
+      "gold": [["bardz", "ROOT_ALLOMORPH"], ["iej", "ADV_COMPARATIVE"]]
+    },
+    {
+      "id": "adv_comp_najbardziej",
+      "category": "adverb_comparative",
+      "surface": "najbardziej",
+      "expected_morph_tags": ["adv:sup"],
+      "gold": [["naj", "PREFIX"], ["bardz", "ROOT_ALLOMORPH"], ["iej", "ADV_COMPARATIVE"]]
+    },
+    {
+      "id": "pron_kolwiek_kogo",
+      "category": "indefinite_pronoun",
+      "surface": "kogokolwiek",
+      "expected_morph_tags": ["subst:sg:gen", "subst:sg:acc"],
+      "gold": [["kogo", "PRONOUN_BASE"], ["kolwiek", "INDEF_PARTICLE"]]
+    },
+    {
+      "id": "pron_kolwiek_czego",
+      "category": "indefinite_pronoun",
+      "surface": "czegokolwiek",
+      "expected_morph_tags": ["subst:sg:gen", "subst:sg:acc"],
+      "gold": [["czego", "PRONOUN_BASE"], ["kolwiek", "INDEF_PARTICLE"]]
+    },
+    {
+      "id": "verb_pref_przemierzaja",
+      "category": "prefixed_verb_theme",
+      "surface": "przemierzają",
+      "expected_morph_tags": ["fin:pl:ter"],
+      "gold": [["prze", "PREFIX"], ["mierz", "ROOT"], ["aj", "VERB_THEME"], ["ą", "PRES_3PL"]]
+    },
+    {
+      "id": "verb_pref_odmierzaja",
+      "category": "prefixed_verb_theme",
+      "surface": "odmierzają",
+      "expected_morph_tags": ["fin:pl:ter"],
+      "gold": [["od", "PREFIX"], ["mierz", "ROOT"], ["aj", "VERB_THEME"], ["ą", "PRES_3PL"]]
+    },
+    {
+      "id": "adj_stem_ext_innego",
+      "category": "adjective_stem_extension",
+      "surface": "innego",
+      "expected_morph_tags": ["adj:sg:gen", "adj:sg:acc"],
+      "gold": [["in", "ROOT"], ["n", "STEM_EXT"], ["ego", "GEN_SG_MN_ADJ"]]
+    },
+    {
+      "id": "adj_stem_ext_czynnego",
+      "category": "adjective_stem_extension",
+      "surface": "czynnego",
+      "expected_morph_tags": ["adj:sg:gen", "adj:sg:acc"],
+      "gold": [["czyn", "ROOT"], ["n", "STEM_EXT"], ["ego", "GEN_SG_MN_ADJ"]]
+    },
+    {
+      "id": "noun_alt_psem",
+      "category": "nominal_root_alternation",
+      "surface": "psem",
+      "expected_morph_tags": ["subst:sg:inst"],
+      "gold": [["ps", "ROOT_ALLOMORPH"], ["em", "INST_SG"]]
+    },
+    {
+      "id": "noun_alt_psu",
+      "category": "nominal_root_alternation",
+      "surface": "psu",
+      "expected_morph_tags": ["subst:sg:dat"],
+      "gold": [["ps", "ROOT_ALLOMORPH"], ["u", "GEN_LOC_SG"]]
+    },
+    {
+      "id": "noun_alt_rece",
+      "category": "nominal_root_alternation",
+      "surface": "ręce",
+      "expected_morph_tags": ["subst:sg:dat", "subst:sg:loc", "subst:pl:nom", "subst:pl:acc"],
+      "gold": [["ręc", "ROOT_ALLOMORPH"], ["e", "NOM_ACC_PL"]]
+    },
+    {
+      "id": "verb_allomorph_przyszlismy",
+      "category": "verbal_root_alternation",
+      "surface": "przyszliśmy",
+      "expected_morph_tags": ["praet:pl"],
+      "gold": [["przy", "PREFIX"], ["sz", "ROOT_ALLOMORPH"], ["liśmy", "PAST_1PL"]]
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/data/polish_samples.txt
+++ b/bench/chomsky_sota2026/data/polish_samples.txt
@@ -1,0 +1,10 @@
+Przyszliśmy wcześniej, ponieważ najprawdopodobniej będzie padało.
+Niepodległościowego przemówienia wysłuchali nauczyciele, uczniowie i urzędnicy.
+Zażółć gęślą jaźń, a później sprawdź, czy wszystkie znaki działają.
+Rozpoznawalność przedsiębiorstw wzrosła po przeprowadzeniu restrukturyzacji.
+Najmniejszymi łyżeczkami mieszaliśmy gorącą herbatę z miodem.
+Dziewięćdziesięciopięcioletnia archiwistka opowiadała o przedwojennych dokumentach.
+W Szczebrzeszynie chrząszcz brzmi w trzcinie i mieszkańcy dobrze to wiedzą.
+Przeanalizowalibyśmy najtrudniejsze przypadki odmiany, gdyby wystarczyło czasu.
+Bezpieczeństwo użytkowników zależy od odpowiedzialnego projektowania interfejsów.
+Książkami, notatkami i załącznikami zarządzaliśmy w międzywydziałowym sekretariacie.

--- a/bench/chomsky_sota2026/data/synthetic_morph_examples.json
+++ b/bench/chomsky_sota2026/data/synthetic_morph_examples.json
@@ -1,0 +1,2592 @@
+{
+  "name": "Synthetic Polish Morphology Stress Set",
+  "version": "0.1.0",
+  "description": "Random template-generated examples for pipeline stress testing. These are not manually verified gold examples.",
+  "seed": 2026,
+  "cases": [
+    {
+      "id": "synthetic_001",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "poszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_002",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "oczem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_003",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kiedykolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kiedy",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_004",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziece",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_005",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "siennego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "sien",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_006",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "biernego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_007",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_008",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "szybciej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "szybc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_009",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "innego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "in",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_010",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "rodzinnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "rodzin",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_011",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "wolniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "woln",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_012",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "częściej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "częśc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_013",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziecu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_014",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "rzadziej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "rzadz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_015",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "czymkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "czym",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_016",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "powołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_017",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "szkolnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "szkol",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_018",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_019",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludzem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_020",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "prawnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "praw",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_021",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludzu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_022",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóżu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_023",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludze",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_024",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "pse",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_025",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "komukolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "komu",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_026",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_027",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "jakkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "jak",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_028",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "czegokolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "czego",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_029",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "gminnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "gmin",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_030",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóże",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_031",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "dziennego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "dzien",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_032",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ocze",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_033",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "trudniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "trudn",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_034",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przepisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_035",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "czynnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "czyn",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_036",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_037",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kimkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kim",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_038",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_039",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kogokolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kogo",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_040",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "daleiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "dale",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_041",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozpisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_042",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_043",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziecem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_044",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręce",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_045",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_046",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wypisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_047",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_048",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręcem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_049",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "gdziekolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "gdzie",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_050",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "winnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "win",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_051",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "bliżiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "bliż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_052",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_053",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_054",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "popisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_055",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zaszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_056",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przewołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_057",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "psu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_058",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "mocniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "mocn",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_059",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przebierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_060",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_061",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_062",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_063",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_064",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dostawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_065",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "bardziej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "bardz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_066",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przenosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_067",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "oczu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_068",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_069",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "łatwiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "łatw",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_070",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóżem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_071",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_072",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_073",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dobierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_074",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "psem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_075",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_076",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "policzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_077",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_078",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "ponosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_079",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_080",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręcu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_081",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zawołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_082",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wykrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_083",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zabierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_084",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "doszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_085",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_086",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wymierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_087",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zanosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_088",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zaczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_089",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_090",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_091",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wyczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_092",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "doczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_093",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_094",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_095",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dowołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_096",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_097",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_098",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zapisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_099",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wyszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_100",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "pokrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/polish_morph_tokenizer.py
+++ b/bench/chomsky_sota2026/polish_morph_tokenizer.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from polish_phoneme_tokenizer import phoneme_syllable_tokens, words
+
+
+@dataclass(frozen=True)
+class MorphToken:
+    text: str
+    role: str
+
+    def render(self) -> str:
+        return f"{self.text}|{self.role}"
+
+
+@dataclass(frozen=True)
+class MorphAnalysis:
+    surface: str
+    tokens: tuple[MorphToken, ...]
+    fallback: bool = False
+    source: str = "heuristic"
+    confidence: float = 0.6
+
+    def render(self) -> str:
+        return " ".join(token.render() for token in self.tokens)
+
+
+PREFIXES = [
+    "naj",
+    "nie",
+    "prze",
+    "przed",
+    "bez",
+    "nad",
+    "pod",
+    "roz",
+    "współ",
+    "między",
+    "wy",
+    "za",
+    "po",
+    "do",
+    "od",
+    "u",
+    "z",
+    "s",
+]
+
+
+FUNCTION_WORDS = {
+    "a": "CONJ",
+    "ale": "CONJ",
+    "czy": "PARTICLE",
+    "do": "PREP",
+    "gdyby": "CONJ_COND",
+    "i": "CONJ",
+    "na": "PREP",
+    "nie": "PARTICLE_NEG",
+    "o": "PREP",
+    "od": "PREP",
+    "po": "PREP",
+    "to": "PARTICLE",
+    "u": "PREP",
+    "w": "PREP",
+    "we": "PREP",
+    "z": "PREP",
+    "za": "PREP",
+    "że": "CONJ",
+}
+
+
+VERB_TAILS = [
+    ("byśmy", "COND_1PL"),
+    ("byście", "COND_2PL"),
+    ("bym", "COND_1SG"),
+    ("byś", "COND_2SG"),
+    ("by", "COND"),
+    ("liśmy", "PAST_1PL"),
+    ("łyśmy", "PAST_1PL_F"),
+    ("liście", "PAST_2PL"),
+    ("łyście", "PAST_2PL_F"),
+    ("łem", "PAST_1SG_M"),
+    ("łam", "PAST_1SG_F"),
+    ("łeś", "PAST_2SG_M"),
+    ("łaś", "PAST_2SG_F"),
+    ("li", "PAST_PL"),
+    ("ły", "PAST_PL_F"),
+    ("ł", "PAST_M"),
+    ("ła", "PAST_F"),
+    ("ło", "PAST_N"),
+]
+
+
+DERIVATIONAL_SUFFIXES = [
+    ("alność", "NOUN_DERIV"),
+    ("alności", "NOUN_DERIV"),
+    ("ości", "NOUN_DERIV"),
+    ("ność", "NOUN_DERIV"),
+    ("stwo", "NOUN_DERIV"),
+    ("stw", "NOUN_DERIV"),
+    ("ciel", "AGENT_DERIV"),
+    ("yciel", "AGENT_DERIV"),
+    ("arka", "AGENT_DERIV"),
+    ("istka", "AGENT_DERIV"),
+    ("owa", "VERB_THEME"),
+    ("ywa", "VERB_THEME"),
+    ("iwa", "VERB_THEME"),
+    ("enie", "NOUN_DERIV"),
+    ("anie", "NOUN_DERIV"),
+    ("owy", "ADJ_DERIV"),
+    ("owa", "ADJ_DERIV"),
+    ("owe", "ADJ_DERIV"),
+    ("ow", "ADJ_DERIV"),
+    ("sk", "ADJ_DERIV"),
+]
+
+
+INFLECTION_ENDINGS = [
+    ("ego", "GEN_SG_MN_ADJ"),
+    ("emu", "DAT_SG_MN_ADJ"),
+    ("ymi", "INST_PL_ADJ"),
+    ("imi", "INST_PL_ADJ"),
+    ("ami", "INST_PL"),
+    ("ach", "LOC_PL"),
+    ("owie", "NOM_PL_PERSONAL"),
+    ("ami", "INST_PL"),
+    ("ego", "GEN_SG"),
+    ("owym", "LOC_INST_SG_ADJ"),
+    ("ymi", "INST_PL"),
+    ("ych", "GEN_LOC_PL_ADJ"),
+    ("ej", "GEN_DAT_LOC_SG_F_ADJ"),
+    ("om", "DAT_PL"),
+    ("ów", "GEN_PL"),
+    ("em", "INST_SG"),
+    ("ie", "LOC_SG"),
+    ("ą", "ACC_INST_SG_F"),
+    ("ę", "ACC_SG"),
+    ("a", "NOM_GEN_SG"),
+    ("u", "GEN_LOC_SG"),
+    ("y", "NOM_ACC_PL"),
+    ("i", "NOM_ACC_PL"),
+    ("e", "NOM_ACC_PL"),
+    ("m", "INST_LOC_SG_ADJ"),
+]
+
+
+SPECIAL_ANALYSES: dict[str, tuple[tuple[str, str], ...]] = {
+    "przyszliśmy": (
+        ("przy", "PREFIX"),
+        ("sz", "ROOT_ALLOMORPH"),
+        ("liśmy", "PAST_1PL"),
+    ),
+    "niepodległościowego": (
+        ("nie", "PREFIX"),
+        ("podleg", "ROOT"),
+        ("łość", "NOUN_DERIV"),
+        ("i", "LINK"),
+        ("ow", "ADJ_DERIV"),
+        ("ego", "GEN_SG_MN_ADJ"),
+    ),
+    "przedsiębiorstw": (
+        ("przedsiębior", "ROOT"),
+        ("stw", "NOUN_DERIV"),
+    ),
+    "dziewięćdziesięciopięcioletnia": (
+        ("dziewięćdziesięcio", "NUM_COMPOUND"),
+        ("pięcio", "NUM_COMPOUND"),
+        ("let", "ROOT"),
+        ("ni", "ADJ_DERIV"),
+        ("a", "NOM_SG_F"),
+    ),
+    "szczebrzeszynie": (
+        ("szczebrzeszyn", "ROOT"),
+        ("ie", "LOC_SG"),
+    ),
+    "chrząszcz": (("chrząszcz", "ROOT"),),
+    "brzmi": (
+        ("brzm", "ROOT"),
+        ("i", "PRES_3SG"),
+    ),
+    "trzcinie": (
+        ("trzcin", "ROOT"),
+        ("ie", "LOC_SG"),
+    ),
+    "mieszkańcy": (
+        ("mieszkań", "ROOT"),
+        ("cy", "NOM_PL_PERSONAL"),
+    ),
+    "dobrze": (
+        ("dobr", "ROOT"),
+        ("ze", "ADV_DERIV"),
+    ),
+    "wiedzą": (
+        ("wiedz", "ROOT"),
+        ("ą", "PRES_3PL"),
+    ),
+    "przeanalizowalibyśmy": (
+        ("prze", "PREFIX"),
+        ("analiz", "ROOT"),
+        ("owa", "VERB_THEME"),
+        ("li", "PAST_PL"),
+        ("byśmy", "COND_1PL"),
+    ),
+    "międzywydziałowym": (
+        ("między", "PREFIX"),
+        ("wydział", "ROOT"),
+        ("ow", "ADJ_DERIV"),
+        ("ym", "LOC_INST_SG_ADJ"),
+    ),
+    "nauczyciele": (
+        ("naucz", "ROOT"),
+        ("yciel", "AGENT_DERIV"),
+        ("e", "NOM_PL_PERSONAL"),
+    ),
+    "urzędnicy": (
+        ("urzęd", "ROOT"),
+        ("nik", "AGENT_DERIV"),
+        ("y", "NOM_PL_PERSONAL"),
+    ),
+}
+
+
+class PolishMorphTokenizer:
+    def analyze_word(self, word: str) -> MorphAnalysis:
+        lowered = word.lower()
+        if lowered in FUNCTION_WORDS:
+            return MorphAnalysis(
+                word,
+                (MorphToken(lowered, FUNCTION_WORDS[lowered]),),
+                source="function_word",
+                confidence=1.0,
+            )
+        if lowered in SPECIAL_ANALYSES:
+            return MorphAnalysis(
+                word,
+                tuple(MorphToken(text, role) for text, role in SPECIAL_ANALYSES[lowered]),
+                source="ladder_entry",
+                confidence=1.0,
+            )
+
+        original = lowered
+        prefixes, stem = self._split_prefixes(lowered)
+        rule_analysis = self._apply_class_rules(word, prefixes, stem)
+        if rule_analysis:
+            return rule_analysis
+
+        suffixes: list[MorphToken] = []
+
+        stem, verb_tails = self._strip_suffixes(stem, VERB_TAILS, min_stem_len=3)
+        suffixes[:0] = verb_tails
+
+        stem, inflections = self._strip_suffixes(stem, INFLECTION_ENDINGS, min_stem_len=3, max_count=1)
+        suffixes[:0] = inflections
+
+        stem, derivations = self._strip_suffixes(stem, DERIVATIONAL_SUFFIXES, min_stem_len=3, max_count=2)
+        suffixes[:0] = derivations
+
+        if len(stem) < 3 or (not prefixes and not suffixes and len(original) > 10):
+            return self._phoneme_fallback(word)
+
+        tokens = [*prefixes, MorphToken(stem, "ROOT"), *suffixes]
+        return MorphAnalysis(word, tuple(tokens), source="heuristic", confidence=0.55)
+
+    def tokenize(self, text: str) -> list[str]:
+        return [token.render() for word in words(text) for token in self.analyze_word(word).tokens]
+
+    def analyses(self, text: str) -> list[MorphAnalysis]:
+        return [self.analyze_word(word) for word in words(text)]
+
+    def _split_prefixes(self, word: str) -> tuple[list[MorphToken], str]:
+        prefixes: list[MorphToken] = []
+        stem = word
+        ordered_prefixes = sorted(PREFIXES, key=len, reverse=True)
+        for _ in range(2):
+            match = next(
+                (prefix for prefix in ordered_prefixes if stem.startswith(prefix) and len(stem) - len(prefix) >= 4),
+                None,
+            )
+            if not match:
+                break
+            prefixes.append(MorphToken(match, "PREFIX"))
+            stem = stem[len(match) :]
+        return prefixes, stem
+
+    def _strip_suffixes(
+        self,
+        stem: str,
+        suffix_table: list[tuple[str, str]],
+        min_stem_len: int,
+        max_count: int | None = None,
+    ) -> tuple[str, list[MorphToken]]:
+        suffixes: list[MorphToken] = []
+        remaining = stem
+        while max_count is None or len(suffixes) < max_count:
+            match = next(
+                (
+                    (suffix, role)
+                    for suffix, role in suffix_table
+                    if remaining.endswith(suffix) and len(remaining) - len(suffix) >= min_stem_len
+                ),
+                None,
+            )
+            if not match:
+                break
+            suffix, role = match
+            suffixes.insert(0, MorphToken(suffix, role))
+            remaining = remaining[: -len(suffix)]
+        return remaining, suffixes
+
+    def _apply_class_rules(self, word: str, prefixes: list[MorphToken], stem: str) -> MorphAnalysis | None:
+        if stem.endswith("kolwiek") and len(stem) - len("kolwiek") >= 2:
+            base = stem[: -len("kolwiek")]
+            return MorphAnalysis(
+                word,
+                (*prefixes, MorphToken(base, "PRONOUN_BASE"), MorphToken("kolwiek", "INDEF_PARTICLE")),
+                source="rule:indefinite_pronoun",
+                confidence=0.9,
+            )
+
+        if stem.endswith("iej") and len(stem) - len("iej") >= 3:
+            return MorphAnalysis(
+                word,
+                (*prefixes, MorphToken(stem[:-3], "ROOT_ALLOMORPH"), MorphToken("iej", "ADV_COMPARATIVE")),
+                source="rule:adverb_comparative",
+                confidence=0.85,
+            )
+
+        if stem.endswith("ają") and len(stem) - len("ają") >= 3:
+            return MorphAnalysis(
+                word,
+                (
+                    *prefixes,
+                    MorphToken(stem[:-3], "ROOT"),
+                    MorphToken("aj", "VERB_THEME"),
+                    MorphToken("ą", "PRES_3PL"),
+                ),
+                source="rule:present_3pl_aja",
+                confidence=0.85,
+            )
+
+        adj_match = next(
+            (
+                (ending, role)
+                for ending, role in INFLECTION_ENDINGS
+                if role.endswith("_ADJ") and stem.endswith(ending) and len(stem) - len(ending) >= 3
+            ),
+            None,
+        )
+        if adj_match:
+            ending, role = adj_match
+            base = stem[: -len(ending)]
+            if base.endswith("nn") and len(base) >= 3:
+                return MorphAnalysis(
+                    word,
+                    (*prefixes, MorphToken(base[:-1], "ROOT"), MorphToken("n", "STEM_EXT"), MorphToken(ending, role)),
+                    source="rule:adjective_stem_extension",
+                    confidence=0.8,
+                )
+
+        return None
+
+    def _phoneme_fallback(self, word: str) -> MorphAnalysis:
+        tokens = tuple(MorphToken(token, "PHON_FALLBACK") for token in phoneme_syllable_tokens(word))
+        return MorphAnalysis(word, tokens, fallback=True, source="phoneme_fallback", confidence=0.25)
+
+
+def morph_tokens(text: str) -> list[str]:
+    return PolishMorphTokenizer().tokenize(text)
+
+
+def morph_analyses(text: str) -> list[MorphAnalysis]:
+    return PolishMorphTokenizer().analyses(text)

--- a/bench/chomsky_sota2026/polish_phoneme_tokenizer.py
+++ b/bench/chomsky_sota2026/polish_phoneme_tokenizer.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+
+WORD_RE = re.compile(r"[A-Za-zĄĆĘŁŃÓŚŹŻąćęłńóśźż]+", re.UNICODE)
+
+
+VOWELS = {"a", "e", "i", "o", "u", "y", "ą", "ę"}
+
+
+MULTIGRAPHS = [
+    ("dzi", "dź"),
+    ("ch", "h"),
+    ("cz", "cz"),
+    ("dz", "dz"),
+    ("dż", "dż"),
+    ("dź", "dź"),
+    ("rz", "ż"),
+    ("sz", "sz"),
+]
+
+
+PALATALIZING = {
+    "b": "b'",
+    "p": "p'",
+    "m": "m'",
+    "f": "f'",
+    "w": "w'",
+    "n": "ń",
+    "s": "ś",
+    "z": "ź",
+    "c": "ć",
+    "d": "dź",
+    "t": "t'",
+}
+
+
+VOICELESS = {"p", "t", "k", "f", "s", "ś", "sz", "ć", "cz", "h"}
+VOICED_TO_VOICELESS = {
+    "b": "p",
+    "d": "t",
+    "g": "k",
+    "w": "f",
+    "z": "s",
+    "ź": "ś",
+    "ż": "sz",
+    "dz": "c",
+    "dź": "ć",
+    "dż": "cz",
+}
+
+
+@dataclass(frozen=True)
+class TokenizedWord:
+    surface: str
+    phonemes: tuple[str, ...]
+    syllables: tuple[str, ...]
+
+
+def words(text: str) -> list[str]:
+    return WORD_RE.findall(text)
+
+
+def g2p(word: str) -> list[str]:
+    """A compact rule-based Polish grapheme-to-phoneme pass.
+
+    It handles the most important tokenizer-level phenomena:
+    multigraphs, palatalization before i+vowel, rz/ch normalization,
+    and final devoicing. It intentionally avoids narrow phonetics.
+    """
+
+    w = word.lower()
+    out: list[str] = []
+    i = 0
+
+    while i < len(w):
+        # Softening before a pronounced following vowel: bia -> b' a.
+        if i + 2 < len(w) and w[i + 1] == "i" and w[i + 2] in VOWELS and w[i] in PALATALIZING:
+            out.append(PALATALIZING[w[i]])
+            i += 2
+            continue
+
+        if w.startswith("rz", i):
+            out.append("sz" if _rz_is_devoiced(w, i) else "ż")
+            i += 2
+            continue
+
+        matched = False
+        for graph, phone in MULTIGRAPHS:
+            if w.startswith(graph, i):
+                out.append(phone)
+                i += len(graph)
+                matched = True
+                break
+        if matched:
+            continue
+
+        ch = w[i]
+        if ch == "ó":
+            out.append("u")
+        elif ch == "ł":
+            out.append("ł")
+        elif ch == "ń":
+            out.append("ń")
+        elif ch == "ś":
+            out.append("ś")
+        elif ch == "ź":
+            out.append("ź")
+        elif ch == "ż":
+            out.append("ż")
+        elif ch in VOWELS or ch.isalpha():
+            out.append(ch)
+        i += 1
+
+    return _apply_final_devoicing(out)
+
+
+def _rz_is_devoiced(word: str, idx: int) -> bool:
+    if idx == 0:
+        return False
+    if idx >= 2 and word[idx - 2 : idx] == "ch":
+        return True
+    return word[idx - 1] in {"p", "t", "k"}
+
+
+def _apply_final_devoicing(phones: list[str]) -> list[str]:
+    if not phones:
+        return phones
+    last = phones[-1]
+    if last in VOICED_TO_VOICELESS:
+        phones = phones.copy()
+        phones[-1] = VOICED_TO_VOICELESS[last]
+    return phones
+
+
+def syllabify(phones: list[str]) -> list[str]:
+    """Group phones around vowel nuclei using a simple Polish-friendly onset rule."""
+
+    if not phones:
+        return []
+
+    vowel_positions = [idx for idx, phone in enumerate(phones) if _is_vowel(phone)]
+    if not vowel_positions:
+        return ["".join(phones)]
+
+    boundaries = [0]
+    for left_vowel, right_vowel in zip(vowel_positions, vowel_positions[1:]):
+        cluster_start = left_vowel + 1
+        cluster_end = right_vowel
+        cluster_len = cluster_end - cluster_start
+        if cluster_len <= 0:
+            boundary = right_vowel
+        elif cluster_len == 1:
+            boundary = cluster_start
+        else:
+            # Keep the last consonant or common sonority-friendly pair as onset.
+            onset_len = 2 if _good_onset_pair(phones[cluster_end - 2], phones[cluster_end - 1]) else 1
+            boundary = cluster_end - onset_len
+        boundaries.append(boundary)
+    boundaries.append(len(phones))
+
+    return ["".join(phones[start:end]) for start, end in zip(boundaries, boundaries[1:]) if start < end]
+
+
+def _is_vowel(phone: str) -> bool:
+    return phone in VOWELS
+
+
+def _good_onset_pair(first: str, second: str) -> bool:
+    return (
+        first in {"p", "b", "t", "d", "k", "g", "f", "w", "s", "z", "ś", "ź", "sz", "ż", "h"}
+        and second in {"r", "l", "ł", "j", "w"}
+    )
+
+
+def tokenize_word(word: str) -> TokenizedWord:
+    phones = tuple(g2p(word))
+    return TokenizedWord(surface=word, phonemes=phones, syllables=tuple(syllabify(list(phones))))
+
+
+def phoneme_tokens(text: str) -> list[str]:
+    return [phone for word in words(text) for phone in g2p(word)]
+
+
+def phoneme_syllable_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    for word in words(text):
+        tokens.extend(syllabify(g2p(word)))
+    return tokens
+
+
+def tokenized_words(text: str) -> list[TokenizedWord]:
+    return [tokenize_word(word) for word in words(text)]
+
+
+def detokenize_phoneme_syllables(tokens: Iterable[str]) -> str:
+    return " ".join(tokens)

--- a/bench/chomsky_sota2026/pyproject.toml
+++ b/bench/chomsky_sota2026/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "polish-morph-tokenizer-demo"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "morfeusz2==1.99.15",
+  "tiktoken==0.13.0",
+]

--- a/bench/chomsky_sota2026/reports/downstream_smoke_results.json
+++ b/bench/chomsky_sota2026/reports/downstream_smoke_results.json
@@ -1,0 +1,30 @@
+{
+  "results": [
+    {
+      "system": "standard_bpe_smoke",
+      "train_words": 112,
+      "eval_words": 12,
+      "train_paths": [
+        "data/morph_benchmark.json",
+        "data/synthetic_morph_examples.json"
+      ],
+      "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+      "eval_bigram_perplexity": 24.94584478810969,
+      "eval_fertility": 3.0,
+      "warning": "Bigram smoke test only. Replace with fixed-budget Polish LM pretraining for publishable downstream proof."
+    },
+    {
+      "system": "morph_bpe_constrained_smoke",
+      "train_words": 112,
+      "eval_words": 12,
+      "train_paths": [
+        "data/morph_benchmark.json",
+        "data/synthetic_morph_examples.json"
+      ],
+      "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+      "eval_bigram_perplexity": 19.599544846844733,
+      "eval_fertility": 3.1666666666666665,
+      "warning": "Bigram smoke test only. Replace with fixed-budget Polish LM pretraining for publishable downstream proof."
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/reports/morph_benchmark_report.md
+++ b/bench/chomsky_sota2026/reports/morph_benchmark_report.md
@@ -1,0 +1,153 @@
+# Polish Morphological Boundary Benchmark v0.1.0
+
+Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.
+
+## Summary
+
+| system | cases | boundary F1 | fertility | morph alignment P | morph alignment R | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| polish_morph_current | 12 | 0.833 | 2.583 | 0.833 | 0.833 | 0.000 |
+| phoneme_syllable_baseline | 12 | 0.361 | 2.833 | 0.278 | 0.389 | 1.000 |
+| tiktoken_cl100k | 12 | 0.325 | 3.583 | 0.340 | 0.333 | 0.000 |
+
+## Diagnostics
+
+| system | exact segments | exact roles | source distribution |
+| --- | ---: | ---: | --- |
+| polish_morph_current | 0.833 | 0.750 | `{'rule:adverb_comparative': 2, 'rule:indefinite_pronoun': 2, 'rule:present_3pl_aja': 2, 'rule:adjective_stem_extension': 2, 'heuristic': 3, 'ladder_entry': 1}` |
+| phoneme_syllable_baseline | 0.000 | 0.000 | `{'phoneme_syllable': 12}` |
+| tiktoken_cl100k | 0.083 | 0.000 | `{'tiktoken_cl100k': 12}` |
+
+## Analyzer Coverage
+
+| analyzer | status | recognized | expected tag match | note |
+| --- | --- | ---: | ---: | --- |
+| morfeusz2 | available | 1.000 | 1.000 | form analyzer baseline; does not provide morpheme boundaries |
+| concraft-pl | missing | 0.000 | 0.000 | not installed in this environment |
+
+## Category Breakdown
+
+### polish_morph_current
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 1.000 | 3.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| adverb_comparative | 2 | 1.000 | 2.500 | 1.000 | 1.000 | 1.000 | 0.000 |
+| indefinite_pronoun | 2 | 1.000 | 2.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| nominal_root_alternation | 3 | 0.333 | 1.667 | 0.333 | 0.333 | 0.000 | 0.000 |
+| prefixed_verb_theme | 2 | 1.000 | 4.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| verbal_root_alternation | 1 | 1.000 | 3.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+
+### phoneme_syllable_baseline
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 0.500 | 3.000 | 0.500 | 0.500 | 0.000 | 1.000 |
+| adverb_comparative | 2 | 0.250 | 2.500 | 0.250 | 0.250 | 0.000 | 1.000 |
+| indefinite_pronoun | 2 | 0.500 | 4.000 | 0.333 | 1.000 | 0.000 | 1.000 |
+| nominal_root_alternation | 3 | 0.000 | 1.333 | 0.000 | 0.000 | 0.000 | 1.000 |
+| prefixed_verb_theme | 2 | 0.667 | 4.000 | 0.333 | 0.333 | 0.000 | 1.000 |
+| verbal_root_alternation | 1 | 0.500 | 3.000 | 0.500 | 0.500 | 0.000 | 1.000 |
+
+### tiktoken_cl100k
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 0.583 | 2.500 | 0.750 | 0.500 | 0.000 | 0.000 |
+| adverb_comparative | 2 | 0.200 | 3.000 | 0.167 | 0.250 | 0.000 | 0.000 |
+| indefinite_pronoun | 2 | 0.000 | 6.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| nominal_root_alternation | 3 | 0.333 | 2.333 | 0.333 | 0.333 | 0.000 | 0.000 |
+| prefixed_verb_theme | 2 | 0.500 | 4.000 | 0.500 | 0.500 | 0.000 | 0.000 |
+| verbal_root_alternation | 1 | 0.333 | 5.000 | 0.250 | 0.500 | 0.000 | 0.000 |
+
+## Failures
+
+### polish_morph_current
+
+- `psem` (nominal_root_alternation, heuristic):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `pse|ROOT m|INST_LOC_SG_ADJ`
+- `psu` (nominal_root_alternation, heuristic):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `psu|ROOT`
+- `ręce` (nominal_root_alternation, heuristic):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `ręc|ROOT e|NOM_ACC_PL`
+
+### phoneme_syllable_baseline
+
+- `bardziej` (adverb_comparative, phoneme_syllable):
+  - gold: `bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `bar|PHON_FALLBACK dźej|PHON_FALLBACK`
+- `najbardziej` (adverb_comparative, phoneme_syllable):
+  - gold: `naj|PREFIX bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `naj|PHON_FALLBACK bar|PHON_FALLBACK dźej|PHON_FALLBACK`
+- `kogokolwiek` (indefinite_pronoun, phoneme_syllable):
+  - gold: `kogo|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `ko|PHON_FALLBACK go|PHON_FALLBACK kol|PHON_FALLBACK w'ek|PHON_FALLBACK`
+- `czegokolwiek` (indefinite_pronoun, phoneme_syllable):
+  - gold: `czego|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `cze|PHON_FALLBACK go|PHON_FALLBACK kol|PHON_FALLBACK w'ek|PHON_FALLBACK`
+- `przemierzają` (prefixed_verb_theme, phoneme_syllable):
+  - gold: `prze|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `psze|PHON_FALLBACK m'e|PHON_FALLBACK ża|PHON_FALLBACK ją|PHON_FALLBACK`
+- `odmierzają` (prefixed_verb_theme, phoneme_syllable):
+  - gold: `od|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `od|PHON_FALLBACK m'e|PHON_FALLBACK ża|PHON_FALLBACK ją|PHON_FALLBACK`
+- `innego` (adjective_stem_extension, phoneme_syllable):
+  - gold: `in|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `in|PHON_FALLBACK ne|PHON_FALLBACK go|PHON_FALLBACK`
+- `czynnego` (adjective_stem_extension, phoneme_syllable):
+  - gold: `czyn|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `czyn|PHON_FALLBACK ne|PHON_FALLBACK go|PHON_FALLBACK`
+- `psem` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `psem|PHON_FALLBACK`
+- `psu` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `psu|PHON_FALLBACK`
+- `ręce` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `rę|PHON_FALLBACK ce|PHON_FALLBACK`
+- `przyszliśmy` (verbal_root_alternation, phoneme_syllable):
+  - gold: `przy|PREFIX sz|ROOT_ALLOMORPH liśmy|PAST_1PL`
+  - pred: `pszy|PHON_FALLBACK szliś|PHON_FALLBACK my|PHON_FALLBACK`
+
+### tiktoken_cl100k
+
+- `bardziej` (adverb_comparative, tiktoken_cl100k):
+  - gold: `bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `bard|BPE ziej|BPE`
+- `najbardziej` (adverb_comparative, tiktoken_cl100k):
+  - gold: `naj|PREFIX bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `n|BPE aj|BPE bard|BPE ziej|BPE`
+- `kogokolwiek` (indefinite_pronoun, tiktoken_cl100k):
+  - gold: `kogo|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `k|BPE og|BPE ok|BPE ol|BPE w|BPE iek|BPE`
+- `czegokolwiek` (indefinite_pronoun, tiktoken_cl100k):
+  - gold: `czego|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `cz|BPE eg|BPE ok|BPE ol|BPE w|BPE iek|BPE`
+- `przemierzają` (prefixed_verb_theme, tiktoken_cl100k):
+  - gold: `prze|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `pr|BPE zem|BPE ierz|BPE ają|BPE`
+- `odmierzają` (prefixed_verb_theme, tiktoken_cl100k):
+  - gold: `od|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `od|BPE m|BPE ierz|BPE ają|BPE`
+- `innego` (adjective_stem_extension, tiktoken_cl100k):
+  - gold: `in|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `inn|BPE ego|BPE`
+- `czynnego` (adjective_stem_extension, tiktoken_cl100k):
+  - gold: `czyn|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `cz|BPE yn|BPE nego|BPE`
+- `psem` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `p|BPE sem|BPE`
+- `psu` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `ps|BPE u|BPE`
+- `ręce` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `r|BPE ę|BPE ce|BPE`
+- `przyszliśmy` (verbal_root_alternation, tiktoken_cl100k):
+  - gold: `przy|PREFIX sz|ROOT_ALLOMORPH liśmy|PAST_1PL`
+  - pred: `pr|BPE z|BPE ysz|BPE li|BPE śmy|BPE`

--- a/bench/chomsky_sota2026/reports/morph_benchmark_results.json
+++ b/bench/chomsky_sota2026/reports/morph_benchmark_results.json
@@ -1,0 +1,2027 @@
+{
+  "benchmark": {
+    "name": "Polish Morphological Boundary Benchmark",
+    "version": "0.1.0",
+    "description": "Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.",
+    "cases": [
+      {
+        "id": "adv_comp_bardziej",
+        "category": "adverb_comparative",
+        "surface": "bardziej",
+        "expected_morph_tags": [
+          "adv:com"
+        ],
+        "gold": [
+          [
+            "bardz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "iej",
+            "ADV_COMPARATIVE"
+          ]
+        ]
+      },
+      {
+        "id": "adv_comp_najbardziej",
+        "category": "adverb_comparative",
+        "surface": "najbardziej",
+        "expected_morph_tags": [
+          "adv:sup"
+        ],
+        "gold": [
+          [
+            "naj",
+            "PREFIX"
+          ],
+          [
+            "bardz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "iej",
+            "ADV_COMPARATIVE"
+          ]
+        ]
+      },
+      {
+        "id": "pron_kolwiek_kogo",
+        "category": "indefinite_pronoun",
+        "surface": "kogokolwiek",
+        "expected_morph_tags": [
+          "subst:sg:gen",
+          "subst:sg:acc"
+        ],
+        "gold": [
+          [
+            "kogo",
+            "PRONOUN_BASE"
+          ],
+          [
+            "kolwiek",
+            "INDEF_PARTICLE"
+          ]
+        ]
+      },
+      {
+        "id": "pron_kolwiek_czego",
+        "category": "indefinite_pronoun",
+        "surface": "czegokolwiek",
+        "expected_morph_tags": [
+          "subst:sg:gen",
+          "subst:sg:acc"
+        ],
+        "gold": [
+          [
+            "czego",
+            "PRONOUN_BASE"
+          ],
+          [
+            "kolwiek",
+            "INDEF_PARTICLE"
+          ]
+        ]
+      },
+      {
+        "id": "verb_pref_przemierzaja",
+        "category": "prefixed_verb_theme",
+        "surface": "przemierzają",
+        "expected_morph_tags": [
+          "fin:pl:ter"
+        ],
+        "gold": [
+          [
+            "prze",
+            "PREFIX"
+          ],
+          [
+            "mierz",
+            "ROOT"
+          ],
+          [
+            "aj",
+            "VERB_THEME"
+          ],
+          [
+            "ą",
+            "PRES_3PL"
+          ]
+        ]
+      },
+      {
+        "id": "verb_pref_odmierzaja",
+        "category": "prefixed_verb_theme",
+        "surface": "odmierzają",
+        "expected_morph_tags": [
+          "fin:pl:ter"
+        ],
+        "gold": [
+          [
+            "od",
+            "PREFIX"
+          ],
+          [
+            "mierz",
+            "ROOT"
+          ],
+          [
+            "aj",
+            "VERB_THEME"
+          ],
+          [
+            "ą",
+            "PRES_3PL"
+          ]
+        ]
+      },
+      {
+        "id": "adj_stem_ext_innego",
+        "category": "adjective_stem_extension",
+        "surface": "innego",
+        "expected_morph_tags": [
+          "adj:sg:gen",
+          "adj:sg:acc"
+        ],
+        "gold": [
+          [
+            "in",
+            "ROOT"
+          ],
+          [
+            "n",
+            "STEM_EXT"
+          ],
+          [
+            "ego",
+            "GEN_SG_MN_ADJ"
+          ]
+        ]
+      },
+      {
+        "id": "adj_stem_ext_czynnego",
+        "category": "adjective_stem_extension",
+        "surface": "czynnego",
+        "expected_morph_tags": [
+          "adj:sg:gen",
+          "adj:sg:acc"
+        ],
+        "gold": [
+          [
+            "czyn",
+            "ROOT"
+          ],
+          [
+            "n",
+            "STEM_EXT"
+          ],
+          [
+            "ego",
+            "GEN_SG_MN_ADJ"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_psem",
+        "category": "nominal_root_alternation",
+        "surface": "psem",
+        "expected_morph_tags": [
+          "subst:sg:inst"
+        ],
+        "gold": [
+          [
+            "ps",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "em",
+            "INST_SG"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_psu",
+        "category": "nominal_root_alternation",
+        "surface": "psu",
+        "expected_morph_tags": [
+          "subst:sg:dat"
+        ],
+        "gold": [
+          [
+            "ps",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "u",
+            "GEN_LOC_SG"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_rece",
+        "category": "nominal_root_alternation",
+        "surface": "ręce",
+        "expected_morph_tags": [
+          "subst:sg:dat",
+          "subst:sg:loc",
+          "subst:pl:nom",
+          "subst:pl:acc"
+        ],
+        "gold": [
+          [
+            "ręc",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "e",
+            "NOM_ACC_PL"
+          ]
+        ]
+      },
+      {
+        "id": "verb_allomorph_przyszlismy",
+        "category": "verbal_root_alternation",
+        "surface": "przyszliśmy",
+        "expected_morph_tags": [
+          "praet:pl"
+        ],
+        "gold": [
+          [
+            "przy",
+            "PREFIX"
+          ],
+          [
+            "sz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "liśmy",
+            "PAST_1PL"
+          ]
+        ]
+      }
+    ]
+  },
+  "analyzers": [
+    {
+      "name": "morfeusz2",
+      "status": "available",
+      "recognized_rate": 1.0,
+      "expected_tag_rate": 1.0,
+      "note": "form analyzer baseline; does not provide morpheme boundaries"
+    },
+    {
+      "name": "concraft-pl",
+      "status": "missing",
+      "recognized_rate": 0.0,
+      "expected_tag_rate": 0.0,
+      "note": "not installed in this environment"
+    }
+  ],
+  "results": [
+    {
+      "system": "polish_morph_current",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.8333333333333334,
+        "fertility": 2.5833333333333335,
+        "morph_alignment_precision": 0.8333333333333334,
+        "morph_alignment_recall": 0.8333333333333334,
+        "segment_exact": 0.8333333333333334,
+        "role_exact": 0.75,
+        "fallback_rate": 0.0,
+        "sources": {
+          "rule:adverb_comparative": 2,
+          "rule:indefinite_pronoun": 2,
+          "rule:present_3pl_aja": 2,
+          "rule:adjective_stem_extension": 2,
+          "heuristic": 3,
+          "ladder_entry": 1
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 3.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.5,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 1.6666666666666667,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.3333333333333333,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 4.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 1.0,
+          "fertility": 3.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "source": "rule:adverb_comparative",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "source": "rule:adverb_comparative",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "source": "rule:indefinite_pronoun",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "source": "rule:indefinite_pronoun",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "source": "rule:present_3pl_aja",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "source": "rule:present_3pl_aja",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "source": "rule:adjective_stem_extension",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "source": "rule:adjective_stem_extension",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "pse",
+              "ROOT"
+            ],
+            [
+              "m",
+              "INST_LOC_SG_ADJ"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psu",
+              "ROOT"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "ręc",
+              "ROOT"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "source": "ladder_entry",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        }
+      ]
+    },
+    {
+      "system": "phoneme_syllable_baseline",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.3611111111111111,
+        "fertility": 2.8333333333333335,
+        "morph_alignment_precision": 0.27777777777777773,
+        "morph_alignment_recall": 0.3888888888888889,
+        "segment_exact": 0.0,
+        "role_exact": 0.0,
+        "fallback_rate": 1.0,
+        "sources": {
+          "phoneme_syllable": 12
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.25,
+          "fertility": 2.5,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.25,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.0,
+          "fertility": 1.3333333333333333,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bar",
+              "PHON_FALLBACK"
+            ],
+            [
+              "dźej",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "naj",
+              "PHON_FALLBACK"
+            ],
+            [
+              "bar",
+              "PHON_FALLBACK"
+            ],
+            [
+              "dźej",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "ko",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ],
+            [
+              "kol",
+              "PHON_FALLBACK"
+            ],
+            [
+              "w'ek",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "cze",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ],
+            [
+              "kol",
+              "PHON_FALLBACK"
+            ],
+            [
+              "w'ek",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "psze",
+              "PHON_FALLBACK"
+            ],
+            [
+              "m'e",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ża",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ją",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "PHON_FALLBACK"
+            ],
+            [
+              "m'e",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ża",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ją",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "in",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ne",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "czyn",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ne",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psem",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psu",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "rę",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ce",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pszy",
+              "PHON_FALLBACK"
+            ],
+            [
+              "szliś",
+              "PHON_FALLBACK"
+            ],
+            [
+              "my",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        }
+      ]
+    },
+    {
+      "system": "tiktoken_cl100k",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.325,
+        "fertility": 3.5833333333333335,
+        "morph_alignment_precision": 0.34027777777777773,
+        "morph_alignment_recall": 0.3333333333333333,
+        "segment_exact": 0.08333333333333333,
+        "role_exact": 0.0,
+        "fallback_rate": 0.0,
+        "sources": {
+          "tiktoken_cl100k": 12
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.5833333333333333,
+          "fertility": 2.5,
+          "morph_alignment_precision": 0.75,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.2,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.16666666666666666,
+          "morph_alignment_recall": 0.25,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.0,
+          "fertility": 6.0,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 2.3333333333333335,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.3333333333333333,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 5.0,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bard",
+              "BPE"
+            ],
+            [
+              "ziej",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "n",
+              "BPE"
+            ],
+            [
+              "aj",
+              "BPE"
+            ],
+            [
+              "bard",
+              "BPE"
+            ],
+            [
+              "ziej",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.4,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "k",
+              "BPE"
+            ],
+            [
+              "og",
+              "BPE"
+            ],
+            [
+              "ok",
+              "BPE"
+            ],
+            [
+              "ol",
+              "BPE"
+            ],
+            [
+              "w",
+              "BPE"
+            ],
+            [
+              "iek",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 6,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "cz",
+              "BPE"
+            ],
+            [
+              "eg",
+              "BPE"
+            ],
+            [
+              "ok",
+              "BPE"
+            ],
+            [
+              "ol",
+              "BPE"
+            ],
+            [
+              "w",
+              "BPE"
+            ],
+            [
+              "iek",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 6,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pr",
+              "BPE"
+            ],
+            [
+              "zem",
+              "BPE"
+            ],
+            [
+              "ierz",
+              "BPE"
+            ],
+            [
+              "ają",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "BPE"
+            ],
+            [
+              "m",
+              "BPE"
+            ],
+            [
+              "ierz",
+              "BPE"
+            ],
+            [
+              "ają",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.6666666666666666,
+          "morph_alignment_recall": 0.6666666666666666,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "inn",
+              "BPE"
+            ],
+            [
+              "ego",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "cz",
+              "BPE"
+            ],
+            [
+              "yn",
+              "BPE"
+            ],
+            [
+              "nego",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "p",
+              "BPE"
+            ],
+            [
+              "sem",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "ps",
+              "BPE"
+            ],
+            [
+              "u",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "r",
+              "BPE"
+            ],
+            [
+              "ę",
+              "BPE"
+            ],
+            [
+              "ce",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 3,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pr",
+              "BPE"
+            ],
+            [
+              "z",
+              "BPE"
+            ],
+            [
+              "ysz",
+              "BPE"
+            ],
+            [
+              "li",
+              "BPE"
+            ],
+            [
+              "śmy",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.25,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 5,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        }
+      ]
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/reports/morph_bpe_report.md
+++ b/bench/chomsky_sota2026/reports/morph_bpe_report.md
@@ -1,0 +1,28 @@
+# MorphBPE/SKMT-Style Tokenizer Smoke
+
+This is a constrained-BPE pipeline check on the current tiny Polish gold set, not a final tokenizer result.
+
+| system | cases | boundary F1 | fertility | align P | align R |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| standard_bpe_smoke | 12 | 0.510 | 3.000 | 0.544 | 0.597 |
+| morph_bpe_constrained_smoke | 12 | 0.925 | 3.167 | 0.889 | 1.000 |
+
+## Failures
+
+### standard_bpe_smoke
+
+- `bardziej` gold=`bardz @@ iej` pred=`b @@ a @@ r @@ dziej`
+- `najbardziej` gold=`naj @@ bardz @@ iej` pred=`n @@ aj @@ b @@ a @@ r @@ dziej`
+- `kogokolwiek` gold=`kogo @@ kolwiek` pred=`ko @@ go @@ kolwiek`
+- `czegokolwiek` gold=`czego @@ kolwiek` pred=`cz @@ ego @@ kolwiek`
+- `przemierzają` gold=`prze @@ mierz @@ aj @@ ą` pred=`prze @@ mierzają`
+- `odmierzają` gold=`od @@ mierz @@ aj @@ ą` pred=`od @@ mierzają`
+- `innego` gold=`in @@ n @@ ego` pred=`innego`
+- `czynnego` gold=`czyn @@ n @@ ego` pred=`czy @@ nnego`
+- `przyszliśmy` gold=`przy @@ sz @@ liśmy` pred=`prz @@ y @@ sz @@ li @@ ś @@ m @@ y`
+
+### morph_bpe_constrained_smoke
+
+- `najbardziej` gold=`naj @@ bardz @@ iej` pred=`n @@ aj @@ bardz @@ iej`
+- `czynnego` gold=`czyn @@ n @@ ego` pred=`czy @@ n @@ n @@ ego`
+- `przyszliśmy` gold=`przy @@ sz @@ liśmy` pred=`prz @@ y @@ sz @@ li @@ ś @@ m @@ y`

--- a/bench/chomsky_sota2026/reports/morph_bpe_results.json
+++ b/bench/chomsky_sota2026/reports/morph_bpe_results.json
@@ -1,0 +1,1114 @@
+{
+  "warning": "Smoke run on current gold set. Full MorphBPE/SKMT needs corpus-scale training and downstream LLM evaluation.",
+  "train_paths": [
+    "data/morph_benchmark.json",
+    "data/synthetic_morph_examples.json"
+  ],
+  "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+  "merges": {
+    "standard_bpe": [
+      [
+        "a",
+        "j"
+      ],
+      [
+        "aj",
+        "ą"
+      ],
+      [
+        "i",
+        "e"
+      ],
+      [
+        "c",
+        "z"
+      ],
+      [
+        "g",
+        "o"
+      ],
+      [
+        "r",
+        "z"
+      ],
+      [
+        "k",
+        "o"
+      ],
+      [
+        "e",
+        "go"
+      ],
+      [
+        "o",
+        "d"
+      ],
+      [
+        "d",
+        "z"
+      ],
+      [
+        "ie",
+        "j"
+      ],
+      [
+        "n",
+        "ego"
+      ],
+      [
+        "ko",
+        "l"
+      ],
+      [
+        "s",
+        "z"
+      ],
+      [
+        "kol",
+        "w"
+      ],
+      [
+        "kolw",
+        "ie"
+      ],
+      [
+        "kolwie",
+        "k"
+      ],
+      [
+        "r",
+        "o"
+      ],
+      [
+        "p",
+        "rz"
+      ],
+      [
+        "n",
+        "nego"
+      ],
+      [
+        "cz",
+        "y"
+      ],
+      [
+        "prz",
+        "e"
+      ],
+      [
+        "sz",
+        "u"
+      ],
+      [
+        "szu",
+        "k"
+      ],
+      [
+        "szuk",
+        "ają"
+      ],
+      [
+        "b",
+        "ie"
+      ],
+      [
+        "bie",
+        "r"
+      ],
+      [
+        "w",
+        "o"
+      ],
+      [
+        "n",
+        "a"
+      ],
+      [
+        "na",
+        "d"
+      ],
+      [
+        "s",
+        "ają"
+      ],
+      [
+        "e",
+        "m"
+      ],
+      [
+        "l",
+        "i"
+      ],
+      [
+        "wo",
+        "ł"
+      ],
+      [
+        "woł",
+        "ają"
+      ],
+      [
+        "bier",
+        "ają"
+      ],
+      [
+        "m",
+        "ie"
+      ],
+      [
+        "mie",
+        "rz"
+      ],
+      [
+        "mierz",
+        "ają"
+      ],
+      [
+        "p",
+        "o"
+      ],
+      [
+        "z",
+        "a"
+      ],
+      [
+        "czy",
+        "t"
+      ],
+      [
+        "czyt",
+        "ają"
+      ],
+      [
+        "i",
+        "nnego"
+      ],
+      [
+        "p",
+        "s"
+      ],
+      [
+        "dz",
+        "ie"
+      ],
+      [
+        "li",
+        "cz"
+      ],
+      [
+        "licz",
+        "ają"
+      ],
+      [
+        "ro",
+        "z"
+      ],
+      [
+        "a",
+        "w"
+      ],
+      [
+        "p",
+        "i"
+      ],
+      [
+        "pi",
+        "sają"
+      ],
+      [
+        "w",
+        "y"
+      ],
+      [
+        "k",
+        "ro"
+      ],
+      [
+        "kro",
+        "j"
+      ],
+      [
+        "kroj",
+        "ają"
+      ],
+      [
+        "d",
+        "o"
+      ],
+      [
+        "p",
+        "od"
+      ],
+      [
+        "dz",
+        "iej"
+      ],
+      [
+        "r",
+        "ę"
+      ],
+      [
+        "rę",
+        "c"
+      ],
+      [
+        "s",
+        "t"
+      ],
+      [
+        "st",
+        "aw"
+      ],
+      [
+        "staw",
+        "ają"
+      ]
+    ],
+    "morph_bpe": [
+      [
+        "a",
+        "j"
+      ],
+      [
+        "i",
+        "e"
+      ],
+      [
+        "c",
+        "z"
+      ],
+      [
+        "g",
+        "o"
+      ],
+      [
+        "r",
+        "z"
+      ],
+      [
+        "k",
+        "o"
+      ],
+      [
+        "e",
+        "go"
+      ],
+      [
+        "o",
+        "d"
+      ],
+      [
+        "d",
+        "z"
+      ],
+      [
+        "ie",
+        "j"
+      ],
+      [
+        "ko",
+        "l"
+      ],
+      [
+        "s",
+        "z"
+      ],
+      [
+        "kol",
+        "w"
+      ],
+      [
+        "kolw",
+        "ie"
+      ],
+      [
+        "kolwie",
+        "k"
+      ],
+      [
+        "r",
+        "o"
+      ],
+      [
+        "p",
+        "rz"
+      ],
+      [
+        "cz",
+        "y"
+      ],
+      [
+        "prz",
+        "e"
+      ],
+      [
+        "sz",
+        "u"
+      ],
+      [
+        "szu",
+        "k"
+      ],
+      [
+        "b",
+        "ie"
+      ],
+      [
+        "bie",
+        "r"
+      ],
+      [
+        "w",
+        "o"
+      ],
+      [
+        "n",
+        "a"
+      ],
+      [
+        "na",
+        "d"
+      ],
+      [
+        "e",
+        "m"
+      ],
+      [
+        "l",
+        "i"
+      ],
+      [
+        "wo",
+        "ł"
+      ],
+      [
+        "m",
+        "ie"
+      ],
+      [
+        "mie",
+        "rz"
+      ],
+      [
+        "p",
+        "o"
+      ],
+      [
+        "z",
+        "a"
+      ],
+      [
+        "czy",
+        "t"
+      ],
+      [
+        "i",
+        "n"
+      ],
+      [
+        "p",
+        "s"
+      ],
+      [
+        "dz",
+        "ie"
+      ],
+      [
+        "li",
+        "cz"
+      ],
+      [
+        "ro",
+        "z"
+      ],
+      [
+        "a",
+        "w"
+      ],
+      [
+        "p",
+        "i"
+      ],
+      [
+        "pi",
+        "s"
+      ],
+      [
+        "w",
+        "y"
+      ],
+      [
+        "k",
+        "ro"
+      ],
+      [
+        "kro",
+        "j"
+      ],
+      [
+        "d",
+        "o"
+      ],
+      [
+        "p",
+        "od"
+      ],
+      [
+        "r",
+        "ę"
+      ],
+      [
+        "rę",
+        "c"
+      ],
+      [
+        "s",
+        "t"
+      ],
+      [
+        "st",
+        "aw"
+      ],
+      [
+        "b",
+        "a"
+      ],
+      [
+        "ba",
+        "r"
+      ],
+      [
+        "bar",
+        "dz"
+      ],
+      [
+        "o",
+        "cz"
+      ],
+      [
+        "dzie",
+        "c"
+      ],
+      [
+        "l",
+        "u"
+      ],
+      [
+        "lu",
+        "dz"
+      ],
+      [
+        "n",
+        "ó"
+      ],
+      [
+        "nó",
+        "ż"
+      ],
+      [
+        "n",
+        "o"
+      ],
+      [
+        "no",
+        "s"
+      ],
+      [
+        "ko",
+        "go"
+      ],
+      [
+        "cz",
+        "ego"
+      ]
+    ]
+  },
+  "results": [
+    {
+      "system": "standard_bpe_smoke",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.5099206349206349,
+        "fertility": 3.0,
+        "alignment_precision": 0.5444444444444444,
+        "alignment_recall": 0.5972222222222222
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.0,
+          "fertility": 1.5,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.14285714285714288,
+          "fertility": 5.0,
+          "alignment_precision": 0.1,
+          "alignment_recall": 0.25
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3.0,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 7.0,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      },
+      "rows": [
+        {
+          "surface": "bardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "b",
+            "a",
+            "r",
+            "dziej"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 4,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "najbardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "naj",
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "n",
+            "aj",
+            "b",
+            "a",
+            "r",
+            "dziej"
+          ],
+          "boundary_precision": 0.2,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.28571428571428575,
+          "fertility": 6,
+          "alignment_precision": 0.2,
+          "alignment_recall": 0.5
+        },
+        {
+          "surface": "kogokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "kogo",
+            "kolwiek"
+          ],
+          "predicted": [
+            "ko",
+            "go",
+            "kolwiek"
+          ],
+          "boundary_precision": 0.5,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czegokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "czego",
+            "kolwiek"
+          ],
+          "predicted": [
+            "cz",
+            "ego",
+            "kolwiek"
+          ],
+          "boundary_precision": 0.5,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przemierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "prze",
+            "mierzają"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.5,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        {
+          "surface": "odmierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "od",
+            "mierzają"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.5,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        {
+          "surface": "innego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "innego"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "czynnego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "czyn",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "czy",
+            "nnego"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "psem",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "em"
+          ],
+          "predicted": [
+            "ps",
+            "em"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psu",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "u"
+          ],
+          "predicted": [
+            "ps",
+            "u"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "ręce",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ręc",
+            "e"
+          ],
+          "predicted": [
+            "ręc",
+            "e"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przyszliśmy",
+          "category": "verbal_root_alternation",
+          "gold": [
+            "przy",
+            "sz",
+            "liśmy"
+          ],
+          "predicted": [
+            "prz",
+            "y",
+            "sz",
+            "li",
+            "ś",
+            "m",
+            "y"
+          ],
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 7,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      ]
+    },
+    {
+      "system": "morph_bpe_constrained_smoke",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.9249999999999999,
+        "fertility": 3.1666666666666665,
+        "alignment_precision": 0.8888888888888888,
+        "alignment_recall": 1.0
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.9,
+          "fertility": 3.5,
+          "alignment_precision": 0.8333333333333333,
+          "alignment_recall": 1.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.9,
+          "fertility": 3.0,
+          "alignment_precision": 0.8333333333333333,
+          "alignment_recall": 1.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 4.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 7.0,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      },
+      "rows": [
+        {
+          "surface": "bardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "bardz",
+            "iej"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "najbardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "naj",
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "n",
+            "aj",
+            "bardz",
+            "iej"
+          ],
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.8,
+          "fertility": 4,
+          "alignment_precision": 0.6666666666666666,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "kogokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "kogo",
+            "kolwiek"
+          ],
+          "predicted": [
+            "kogo",
+            "kolwiek"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czegokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "czego",
+            "kolwiek"
+          ],
+          "predicted": [
+            "czego",
+            "kolwiek"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przemierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "odmierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "innego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czynnego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "czyn",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "czy",
+            "n",
+            "n",
+            "ego"
+          ],
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.8,
+          "fertility": 4,
+          "alignment_precision": 0.6666666666666666,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psem",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "em"
+          ],
+          "predicted": [
+            "ps",
+            "em"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psu",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "u"
+          ],
+          "predicted": [
+            "ps",
+            "u"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "ręce",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ręc",
+            "e"
+          ],
+          "predicted": [
+            "ręc",
+            "e"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przyszliśmy",
+          "category": "verbal_root_alternation",
+          "gold": [
+            "przy",
+            "sz",
+            "liśmy"
+          ],
+          "predicted": [
+            "prz",
+            "y",
+            "sz",
+            "li",
+            "ś",
+            "m",
+            "y"
+          ],
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 7,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      ]
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/reports/neural_segmenter_results.json
+++ b/bench/chomsky_sota2026/reports/neural_segmenter_results.json
@@ -1,0 +1,212 @@
+{
+  "summary": {
+    "system": "neural_char_boundary_tagger_smoke",
+    "train_paths": [
+      "data/morph_benchmark.json",
+      "data/synthetic_morph_examples.json"
+    ],
+    "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+    "train_cases": 112,
+    "cases": 12,
+    "boundary_f1": 1.0,
+    "warning": "Smoke run on the tiny current gold set. This is pipeline validation, not a SOTA result."
+  },
+  "rows": [
+    {
+      "surface": "bardziej",
+      "category": "adverb_comparative",
+      "gold": [
+        "bardz",
+        "iej"
+      ],
+      "predicted": [
+        "bardz",
+        "iej"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "najbardziej",
+      "category": "adverb_comparative",
+      "gold": [
+        "naj",
+        "bardz",
+        "iej"
+      ],
+      "predicted": [
+        "naj",
+        "bardz",
+        "iej"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "kogokolwiek",
+      "category": "indefinite_pronoun",
+      "gold": [
+        "kogo",
+        "kolwiek"
+      ],
+      "predicted": [
+        "kogo",
+        "kolwiek"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "czegokolwiek",
+      "category": "indefinite_pronoun",
+      "gold": [
+        "czego",
+        "kolwiek"
+      ],
+      "predicted": [
+        "czego",
+        "kolwiek"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "przemierzają",
+      "category": "prefixed_verb_theme",
+      "gold": [
+        "prze",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "predicted": [
+        "prze",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "odmierzają",
+      "category": "prefixed_verb_theme",
+      "gold": [
+        "od",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "predicted": [
+        "od",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "innego",
+      "category": "adjective_stem_extension",
+      "gold": [
+        "in",
+        "n",
+        "ego"
+      ],
+      "predicted": [
+        "in",
+        "n",
+        "ego"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "czynnego",
+      "category": "adjective_stem_extension",
+      "gold": [
+        "czyn",
+        "n",
+        "ego"
+      ],
+      "predicted": [
+        "czyn",
+        "n",
+        "ego"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "psem",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ps",
+        "em"
+      ],
+      "predicted": [
+        "ps",
+        "em"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "psu",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ps",
+        "u"
+      ],
+      "predicted": [
+        "ps",
+        "u"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "ręce",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ręc",
+        "e"
+      ],
+      "predicted": [
+        "ręc",
+        "e"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "przyszliśmy",
+      "category": "verbal_root_alternation",
+      "gold": [
+        "przy",
+        "sz",
+        "liśmy"
+      ],
+      "predicted": [
+        "przy",
+        "sz",
+        "liśmy"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    }
+  ]
+}

--- a/bench/chomsky_sota2026/reports/sigmorphon_export/metadata.tsv
+++ b/bench/chomsky_sota2026/reports/sigmorphon_export/metadata.tsv
@@ -1,0 +1,13 @@
+id	surface	category	split	lemma	expected_morph_tags
+adv_comp_bardziej	bardziej	adverb_comparative	dev		adv:com
+adv_comp_najbardziej	najbardziej	adverb_comparative	dev		adv:sup
+pron_kolwiek_kogo	kogokolwiek	indefinite_pronoun	dev		subst:sg:gen,subst:sg:acc
+pron_kolwiek_czego	czegokolwiek	indefinite_pronoun	dev		subst:sg:gen,subst:sg:acc
+verb_pref_przemierzaja	przemierzają	prefixed_verb_theme	dev		fin:pl:ter
+verb_pref_odmierzaja	odmierzają	prefixed_verb_theme	dev		fin:pl:ter
+adj_stem_ext_innego	innego	adjective_stem_extension	dev		adj:sg:gen,adj:sg:acc
+adj_stem_ext_czynnego	czynnego	adjective_stem_extension	dev		adj:sg:gen,adj:sg:acc
+noun_alt_psem	psem	nominal_root_alternation	dev		subst:sg:inst
+noun_alt_psu	psu	nominal_root_alternation	dev		subst:sg:dat
+noun_alt_rece	ręce	nominal_root_alternation	dev		subst:sg:dat,subst:sg:loc,subst:pl:nom,subst:pl:acc
+verb_allomorph_przyszlismy	przyszliśmy	verbal_root_alternation	dev		praet:pl

--- a/bench/chomsky_sota2026/reports/sigmorphon_export/word_level_gold.tsv
+++ b/bench/chomsky_sota2026/reports/sigmorphon_export/word_level_gold.tsv
@@ -1,0 +1,12 @@
+bardziej	bardz @@ iej
+najbardziej	naj @@ bardz @@ iej
+kogokolwiek	kogo @@ kolwiek
+czegokolwiek	czego @@ kolwiek
+przemierzają	prze @@ mierz @@ aj @@ ą
+odmierzają	od @@ mierz @@ aj @@ ą
+innego	in @@ n @@ ego
+czynnego	czyn @@ n @@ ego
+psem	ps @@ em
+psu	ps @@ u
+ręce	ręc @@ e
+przyszliśmy	przy @@ sz @@ liśmy

--- a/bench/chomsky_sota2026/reports/sigmorphon_export/word_level_gold_with_roles.tsv
+++ b/bench/chomsky_sota2026/reports/sigmorphon_export/word_level_gold_with_roles.tsv
@@ -1,0 +1,12 @@
+bardziej	bardz|ROOT_ALLOMORPH @@ iej|ADV_COMPARATIVE
+najbardziej	naj|PREFIX @@ bardz|ROOT_ALLOMORPH @@ iej|ADV_COMPARATIVE
+kogokolwiek	kogo|PRONOUN_BASE @@ kolwiek|INDEF_PARTICLE
+czegokolwiek	czego|PRONOUN_BASE @@ kolwiek|INDEF_PARTICLE
+przemierzają	prze|PREFIX @@ mierz|ROOT @@ aj|VERB_THEME @@ ą|PRES_3PL
+odmierzają	od|PREFIX @@ mierz|ROOT @@ aj|VERB_THEME @@ ą|PRES_3PL
+innego	in|ROOT @@ n|STEM_EXT @@ ego|GEN_SG_MN_ADJ
+czynnego	czyn|ROOT @@ n|STEM_EXT @@ ego|GEN_SG_MN_ADJ
+psem	ps|ROOT_ALLOMORPH @@ em|INST_SG
+psu	ps|ROOT_ALLOMORPH @@ u|GEN_LOC_SG
+ręce	ręc|ROOT_ALLOMORPH @@ e|NOM_ACC_PL
+przyszliśmy	przy|PREFIX @@ sz|ROOT_ALLOMORPH @@ liśmy|PAST_1PL

--- a/bench/chomsky_sota2026/requirements.txt
+++ b/bench/chomsky_sota2026/requirements.txt
@@ -1,0 +1,2 @@
+morfeusz2==1.99.15
+tiktoken==0.13.0

--- a/bench/chomsky_sota2026/scripts/evaluate_morph_segmentation.py
+++ b/bench/chomsky_sota2026/scripts/evaluate_morph_segmentation.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from polish_morph_tokenizer import MorphToken, PolishMorphTokenizer
+from polish_phoneme_tokenizer import phoneme_syllable_tokens
+
+
+BENCHMARK_PATH = ROOT / "data" / "morph_benchmark.json"
+REPORT_DIR = ROOT / "reports"
+
+
+@dataclass(frozen=True)
+class Prediction:
+    tokens: tuple[MorphToken, ...]
+    source: str
+    fallback: bool
+
+
+def boundaries(tokens: Iterable[MorphToken]) -> set[int]:
+    offsets = []
+    cursor = 0
+    token_list = list(tokens)
+    for token in token_list[:-1]:
+        cursor += len(token.text)
+        offsets.append(cursor)
+    return set(offsets)
+
+
+def byte_boundaries(tokens: Iterable[MorphToken]) -> set[int]:
+    offsets = []
+    cursor = 0
+    token_list = list(tokens)
+    for token in token_list[:-1]:
+        cursor += len(token.text.encode("utf-8"))
+        offsets.append(cursor)
+    return set(offsets)
+
+
+def f1(predicted: set[int], gold: set[int]) -> tuple[float, float, float]:
+    if not predicted and not gold:
+        return 1.0, 1.0, 1.0
+    true_positive = len(predicted & gold)
+    precision = true_positive / len(predicted) if predicted else 0.0
+    recall = true_positive / len(gold) if gold else 0.0
+    score = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return precision, recall, score
+
+
+def alignment(predicted: set[int], gold: set[int]) -> tuple[float, float]:
+    if not predicted and not gold:
+        return 1.0, 1.0
+    precision = len(predicted & gold) / len(predicted) if predicted else 0.0
+    recall = len(predicted & gold) / len(gold) if gold else 0.0
+    return precision, recall
+
+
+def exact_tokens(tokens: Iterable[MorphToken]) -> list[list[str]]:
+    return [[token.text, token.role] for token in tokens]
+
+
+def evaluate_system(name: str, cases: list[dict], predictor) -> dict:
+    rows = []
+    category_scores = defaultdict(list)
+    source_counts = Counter()
+    fallback_count = 0
+
+    for case in cases:
+        gold_tokens = tuple(MorphToken(text, role) for text, role in case["gold"])
+        prediction = predictor(case["surface"])
+        predicted_tokens = prediction.tokens
+        predicted_boundary = boundaries(predicted_tokens)
+        gold_boundary = boundaries(gold_tokens)
+        precision, recall, boundary_f1 = f1(predicted_boundary, gold_boundary)
+        alignment_precision, alignment_recall = alignment(byte_boundaries(predicted_tokens), byte_boundaries(gold_tokens))
+        segment_exact = [token.text for token in predicted_tokens] == [token.text for token in gold_tokens]
+        role_exact = exact_tokens(predicted_tokens) == exact_tokens(gold_tokens)
+        row = {
+            "id": case["id"],
+            "category": case["category"],
+            "surface": case["surface"],
+            "gold": exact_tokens(gold_tokens),
+            "predicted": exact_tokens(predicted_tokens),
+            "source": prediction.source,
+            "fallback": prediction.fallback,
+            "boundary_precision": precision,
+            "boundary_recall": recall,
+            "boundary_f1": boundary_f1,
+            "fertility": len(predicted_tokens),
+            "morph_alignment_precision": alignment_precision,
+            "morph_alignment_recall": alignment_recall,
+            "segment_exact": segment_exact,
+            "role_exact": role_exact,
+        }
+        rows.append(row)
+        category_scores[case["category"]].append(row)
+        source_counts[prediction.source] += 1
+        fallback_count += int(prediction.fallback)
+
+    def avg(items: list[float]) -> float:
+        return sum(items) / len(items) if items else 0.0
+
+    categories = {}
+    for category, category_rows in sorted(category_scores.items()):
+        categories[category] = {
+            "cases": len(category_rows),
+            "boundary_f1": avg([row["boundary_f1"] for row in category_rows]),
+            "fertility": avg([row["fertility"] for row in category_rows]),
+            "morph_alignment_precision": avg([row["morph_alignment_precision"] for row in category_rows]),
+            "morph_alignment_recall": avg([row["morph_alignment_recall"] for row in category_rows]),
+            "segment_exact": avg([float(row["segment_exact"]) for row in category_rows]),
+            "role_exact": avg([float(row["role_exact"]) for row in category_rows]),
+            "fallback_rate": avg([float(row["fallback"]) for row in category_rows]),
+        }
+
+    return {
+        "system": name,
+        "summary": {
+            "cases": len(rows),
+            "boundary_f1": avg([row["boundary_f1"] for row in rows]),
+            "fertility": avg([row["fertility"] for row in rows]),
+            "morph_alignment_precision": avg([row["morph_alignment_precision"] for row in rows]),
+            "morph_alignment_recall": avg([row["morph_alignment_recall"] for row in rows]),
+            "segment_exact": avg([float(row["segment_exact"]) for row in rows]),
+            "role_exact": avg([float(row["role_exact"]) for row in rows]),
+            "fallback_rate": fallback_count / len(rows) if rows else 0.0,
+            "sources": dict(source_counts),
+        },
+        "categories": categories,
+        "rows": rows,
+    }
+
+
+def render_markdown(results: list[dict], benchmark: dict) -> str:
+    lines = [
+        f"# {benchmark['name']} v{benchmark['version']}",
+        "",
+        benchmark["description"],
+        "",
+        "## Summary",
+        "",
+        "| system | cases | boundary F1 | fertility | morph alignment P | morph alignment R | fallback |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        summary = result["summary"]
+        lines.append(
+            "| {system} | {cases} | {boundary_f1:.3f} | {fertility:.3f} | {morph_alignment_precision:.3f} | {morph_alignment_recall:.3f} | {fallback_rate:.3f} |".format(
+                system=result["system"],
+                **summary,
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Diagnostics",
+            "",
+            "| system | exact segments | exact roles | source distribution |",
+            "| --- | ---: | ---: | --- |",
+        ]
+    )
+    for result in results:
+        summary = result["summary"]
+        lines.append(
+            "| {system} | {segment_exact:.3f} | {role_exact:.3f} | `{sources}` |".format(
+                system=result["system"],
+                **summary,
+            )
+        )
+
+    analyzers = benchmark.get("analyzers", [])
+    if analyzers:
+        lines.extend(
+            [
+                "",
+                "## Analyzer Coverage",
+                "",
+                "| analyzer | status | recognized | expected tag match | note |",
+                "| --- | --- | ---: | ---: | --- |",
+            ]
+        )
+        for analyzer in analyzers:
+            lines.append(
+                "| {name} | {status} | {recognized_rate:.3f} | {expected_tag_rate:.3f} | {note} |".format(
+                    **analyzer
+                )
+            )
+
+    lines.extend(["", "## Category Breakdown", ""])
+    for result in results:
+        lines.extend([f"### {result['system']}", ""])
+        lines.append("| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |")
+        lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for category, metrics in result["categories"].items():
+            lines.append(
+                "| {category} | {cases} | {boundary_f1:.3f} | {fertility:.3f} | {morph_alignment_precision:.3f} | {morph_alignment_recall:.3f} | {role_exact:.3f} | {fallback_rate:.3f} |".format(
+                    category=category,
+                    **metrics,
+                )
+            )
+        lines.append("")
+
+    lines.extend(["## Failures", ""])
+    for result in results:
+        lines.extend([f"### {result['system']}", ""])
+        failures = [row for row in result["rows"] if not row["role_exact"]]
+        if not failures:
+            lines.append("No role-level failures.")
+            lines.append("")
+            continue
+        for row in failures:
+            lines.append(f"- `{row['surface']}` ({row['category']}, {row['source']}):")
+            lines.append(f"  - gold: `{format_tokens(row['gold'])}`")
+            lines.append(f"  - pred: `{format_tokens(row['predicted'])}`")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_tokens(tokens: list[list[str]]) -> str:
+    return " ".join(f"{text}|{role}" for text, role in tokens)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--benchmark", type=Path, default=BENCHMARK_PATH)
+    parser.add_argument("--json-out", type=Path, default=REPORT_DIR / "morph_benchmark_results.json")
+    parser.add_argument("--md-out", type=Path, default=REPORT_DIR / "morph_benchmark_report.md")
+    args = parser.parse_args()
+
+    benchmark = json.loads(args.benchmark.read_text(encoding="utf-8"))
+    cases = benchmark["cases"]
+    tokenizer = PolishMorphTokenizer()
+
+    def current_predictor(surface: str) -> Prediction:
+        analysis = tokenizer.analyze_word(surface)
+        return Prediction(analysis.tokens, analysis.source, analysis.fallback)
+
+    def phoneme_predictor(surface: str) -> Prediction:
+        return Prediction(
+            tuple(MorphToken(token, "PHON_FALLBACK") for token in phoneme_syllable_tokens(surface)),
+            "phoneme_syllable",
+            True,
+        )
+
+    results = [
+        evaluate_system("polish_morph_current", cases, current_predictor),
+        evaluate_system("phoneme_syllable_baseline", cases, phoneme_predictor),
+    ]
+    try:
+        import tiktoken
+    except Exception:
+        tiktoken = None
+
+    if tiktoken:
+        encoder = tiktoken.get_encoding("cl100k_base")
+
+        def tiktoken_predictor(surface: str) -> Prediction:
+            token_bytes = encoder.decode_tokens_bytes(encoder.encode(surface))
+            return Prediction(
+                tuple(MorphToken(piece.decode("utf-8", errors="replace"), "BPE") for piece in token_bytes),
+                "tiktoken_cl100k",
+                False,
+            )
+
+        results.append(evaluate_system("tiktoken_cl100k", cases, tiktoken_predictor))
+
+    analyzer_results = [evaluate_morfeusz(cases), missing_analyzer("concraft-pl", "not installed in this environment")]
+    benchmark_with_analyzers = {**benchmark, "analyzers": analyzer_results}
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(
+        json.dumps({"benchmark": benchmark, "analyzers": analyzer_results, "results": results}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    args.md_out.write_text(render_markdown(results, benchmark_with_analyzers), encoding="utf-8")
+
+    for result in results:
+        summary = result["summary"]
+        print(
+            "{system}: boundary_f1={boundary_f1:.3f} fertility={fertility:.3f} align_p={morph_alignment_precision:.3f} align_r={morph_alignment_recall:.3f}".format(
+                system=result["system"],
+                **summary,
+            )
+        )
+    print(f"wrote {args.md_out}")
+    print(f"wrote {args.json_out}")
+
+
+def missing_analyzer(name: str, note: str) -> dict:
+    return {
+        "name": name,
+        "status": "missing",
+        "recognized_rate": 0.0,
+        "expected_tag_rate": 0.0,
+        "note": note,
+    }
+
+
+def evaluate_morfeusz(cases: list[dict]) -> dict:
+    try:
+        import morfeusz2
+    except Exception:
+        return missing_analyzer("morfeusz2", "not installed for this Python interpreter")
+
+    analyzer = morfeusz2.Morfeusz()
+    recognized = 0
+    expected_tag = 0
+    for case in cases:
+        rows = analyzer.analyse(case["surface"])
+        tags = [interp[2] for _, _, interp in rows]
+        if any(tag != "ign" for tag in tags):
+            recognized += 1
+        expected = case.get("expected_morph_tags", [])
+        if expected and any(any(tag.startswith(prefix) for prefix in expected) for tag in tags):
+            expected_tag += 1
+
+    total = len(cases) or 1
+    return {
+        "name": "morfeusz2",
+        "status": "available",
+        "recognized_rate": recognized / total,
+        "expected_tag_rate": expected_tag / total,
+        "note": "form analyzer baseline; does not provide morpheme boundaries",
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/export_sigmorphon_format.py
+++ b/bench/chomsky_sota2026/scripts/export_sigmorphon_format.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BENCHMARK = ROOT / "data" / "morph_benchmark.json"
+DEFAULT_OUT_DIR = ROOT / "reports" / "sigmorphon_export"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export Polish morpheme benchmark to SIGMORPHON-style TSV files.")
+    parser.add_argument("--benchmark", type=Path, default=DEFAULT_BENCHMARK)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    args = parser.parse_args()
+
+    benchmark = json.loads(args.benchmark.read_text(encoding="utf-8"))
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    role_free_lines = []
+    role_lines = []
+    metadata_lines = ["id\tsurface\tcategory\tsplit\tlemma\texpected_morph_tags"]
+
+    for case in benchmark["cases"]:
+        surface = case["surface"]
+        split = case.get("split", "dev")
+        lemma = case.get("lemma", "")
+        expected_tags = ",".join(case.get("expected_morph_tags", []))
+        pieces = [piece for piece, _ in case["gold"]]
+        role_pieces = [f"{piece}|{role}" for piece, role in case["gold"]]
+
+        role_free_lines.append(f"{surface}\t{' @@ '.join(pieces)}")
+        role_lines.append(f"{surface}\t{' @@ '.join(role_pieces)}")
+        metadata_lines.append(f"{case['id']}\t{surface}\t{case['category']}\t{split}\t{lemma}\t{expected_tags}")
+
+    (args.out_dir / "word_level_gold.tsv").write_text("\n".join(role_free_lines) + "\n", encoding="utf-8")
+    (args.out_dir / "word_level_gold_with_roles.tsv").write_text("\n".join(role_lines) + "\n", encoding="utf-8")
+    (args.out_dir / "metadata.tsv").write_text("\n".join(metadata_lines) + "\n", encoding="utf-8")
+
+    print(f"wrote {args.out_dir / 'word_level_gold.tsv'}")
+    print(f"wrote {args.out_dir / 'word_level_gold_with_roles.tsv'}")
+    print(f"wrote {args.out_dir / 'metadata.tsv'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/generate_synthetic_morph_examples.py
+++ b/bench/chomsky_sota2026/scripts/generate_synthetic_morph_examples.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = ROOT / "data" / "synthetic_morph_examples.json"
+
+
+PREFIXES = ["prze", "od", "do", "wy", "za", "po", "roz", "pod", "nad"]
+VERB_ROOTS = ["mierz", "licz", "pis", "czyt", "nos", "woł", "bier", "kroj", "szuk", "staw"]
+PRON_BASES = ["kogo", "czego", "komu", "kim", "czym", "gdzie", "kiedy", "jak"]
+ADVERB_BASES = ["bardz", "szybc", "mocn", "łatw", "trudn", "woln", "częśc", "rzadz", "bliż", "dalej"]
+ADJ_ROOTS = ["in", "czyn", "win", "bier", "dzien", "rodzin", "szkol", "gmin", "praw", "sien"]
+NOUN_ALLOMORPHS = [
+    ("ps", "pies"),
+    ("ręc", "ręka"),
+    ("nóż", "noga"),
+    ("ludz", "człowiek"),
+    ("dziec", "dziecko"),
+    ("ocz", "oko"),
+]
+
+
+def make_case(idx: int, rng: random.Random) -> dict:
+    category = rng.choice(
+        [
+            "synthetic_prefixed_verb",
+            "synthetic_indefinite_pronoun",
+            "synthetic_adverb_comparative",
+            "synthetic_adjective_stem_extension",
+            "synthetic_nominal_allomorph",
+        ]
+    )
+
+    if category == "synthetic_prefixed_verb":
+        prefix = rng.choice(PREFIXES)
+        root = rng.choice(VERB_ROOTS)
+        surface = f"{prefix}{root}ają"
+        gold = [[prefix, "PREFIX"], [root, "ROOT"], ["aj", "VERB_THEME"], ["ą", "PRES_3PL"]]
+        expected = ["fin:pl:ter"]
+    elif category == "synthetic_indefinite_pronoun":
+        base = rng.choice(PRON_BASES)
+        surface = f"{base}kolwiek"
+        gold = [[base, "PRONOUN_BASE"], ["kolwiek", "INDEF_PARTICLE"]]
+        expected = []
+    elif category == "synthetic_adverb_comparative":
+        base = rng.choice(ADVERB_BASES)
+        if base.endswith("j"):
+            base = base[:-1]
+        surface = f"{base}iej"
+        gold = [[base, "ROOT_ALLOMORPH"], ["iej", "ADV_COMPARATIVE"]]
+        expected = ["adv:com"]
+    elif category == "synthetic_adjective_stem_extension":
+        root = rng.choice(ADJ_ROOTS)
+        surface = f"{root}nego"
+        gold = [[root, "ROOT"], ["n", "STEM_EXT"], ["ego", "GEN_SG_MN_ADJ"]]
+        expected = ["adj:sg:gen", "adj:sg:acc"]
+    else:
+        root, lemma = rng.choice(NOUN_ALLOMORPHS)
+        ending, role, expected = rng.choice(
+            [
+                ("em", "INST_SG", ["subst:sg:inst"]),
+                ("u", "GEN_LOC_SG", ["subst:sg:gen", "subst:sg:loc", "subst:sg:dat"]),
+                ("e", "NOM_ACC_PL", ["subst:pl:nom", "subst:pl:acc"]),
+            ]
+        )
+        surface = f"{root}{ending}"
+        gold = [[root, "ROOT_ALLOMORPH"], [ending, role]]
+
+    return {
+        "id": f"synthetic_{idx:03d}",
+        "split": "synthetic",
+        "category": category,
+        "surface": surface,
+        "expected_morph_tags": expected,
+        "gold": gold,
+        "provenance": "synthetic_template_generator",
+        "verified": False,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic Polish morphology examples for stress testing.")
+    parser.add_argument("--count", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    seen = set()
+    cases = []
+    attempts = 0
+    while len(cases) < args.count and attempts < args.count * 20:
+        attempts += 1
+        case = make_case(len(cases) + 1, rng)
+        key = (case["surface"], case["category"])
+        if key in seen:
+            continue
+        seen.add(key)
+        cases.append(case)
+
+    payload = {
+        "name": "Synthetic Polish Morphology Stress Set",
+        "version": "0.1.0",
+        "description": "Random template-generated examples for pipeline stress testing. These are not manually verified gold examples.",
+        "seed": args.seed,
+        "cases": cases,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"wrote {len(cases)} examples to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/run_downstream_smoke.py
+++ b/bench/chomsky_sota2026/scripts/run_downstream_smoke.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.sota2026_utils import REPORT_DIR, BigramLM, SimpleBPE, load_gold_words, load_multiple_word_sets
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a cheap downstream smoke test over tokenizer outputs.")
+    parser.add_argument("--merges", type=int, default=64)
+    parser.add_argument("--train", type=Path, nargs="*", default=None)
+    parser.add_argument("--eval", type=Path, default=ROOT / "data" / "morph_benchmark.json")
+    parser.add_argument("--out", type=Path, default=REPORT_DIR / "downstream_smoke_results.json")
+    args = parser.parse_args()
+
+    train_paths = args.train or [ROOT / "data" / "morph_benchmark.json"]
+    train_words = load_multiple_word_sets(train_paths)
+    eval_words = load_gold_words(args.eval)
+
+    tokenizers = {
+        "standard_bpe_smoke": SimpleBPE.train(train_words, args.merges, respect_boundaries=False),
+        "morph_bpe_constrained_smoke": SimpleBPE.train(train_words, args.merges, respect_boundaries=True),
+    }
+
+    results = []
+    for name, tokenizer in tokenizers.items():
+        train_sequences = [tokenizer.encode(word.surface) for word in train_words]
+        eval_sequences = [tokenizer.encode(word.surface) for word in eval_words]
+        lm = BigramLM()
+        lm.fit(train_sequences)
+        results.append(
+            {
+                "system": name,
+                "train_words": len(train_words),
+                "eval_words": len(eval_words),
+                "train_paths": [str(path) for path in train_paths],
+                "eval_path": str(args.eval),
+                "eval_bigram_perplexity": lm.perplexity(eval_sequences),
+                "eval_fertility": sum(len(seq) for seq in eval_sequences) / len(eval_sequences),
+                "warning": "Bigram smoke test only. Replace with fixed-budget Polish LM pretraining for publishable downstream proof.",
+            }
+        )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps({"results": results}, ensure_ascii=False, indent=2), encoding="utf-8")
+    for row in results:
+        print(f"{row['system']}: ppl={row['eval_bigram_perplexity']:.3f} fertility={row['eval_fertility']:.3f}")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/run_morph_bpe.py
+++ b/bench/chomsky_sota2026/scripts/run_morph_bpe.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.sota2026_utils import REPORT_DIR, SimpleBPE, evaluate_piece_tokenizer, load_gold_words, load_multiple_word_sets
+
+
+def render_report(results: list[dict]) -> str:
+    lines = [
+        "# MorphBPE/SKMT-Style Tokenizer Smoke",
+        "",
+        "This is a constrained-BPE pipeline check on the current tiny Polish gold set, not a final tokenizer result.",
+        "",
+        "| system | cases | boundary F1 | fertility | align P | align R |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in results:
+        s = result["summary"]
+        lines.append(
+            f"| {result['system']} | {s['cases']} | {s['boundary_f1']:.3f} | {s['fertility']:.3f} | {s['alignment_precision']:.3f} | {s['alignment_recall']:.3f} |"
+        )
+
+    lines.extend(["", "## Failures", ""])
+    for result in results:
+        lines.extend([f"### {result['system']}", ""])
+        for row in result["rows"]:
+            if row["boundary_f1"] < 1:
+                lines.append(f"- `{row['surface']}` gold=`{' @@ '.join(row['gold'])}` pred=`{' @@ '.join(row['predicted'])}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train standard BPE vs MorphBPE-style constrained BPE on gold morpheme boundaries.")
+    parser.add_argument("--merges", type=int, default=64)
+    parser.add_argument("--train", type=Path, nargs="*", default=None)
+    parser.add_argument("--eval", type=Path, default=ROOT / "data" / "morph_benchmark.json")
+    parser.add_argument("--json-out", type=Path, default=REPORT_DIR / "morph_bpe_results.json")
+    parser.add_argument("--md-out", type=Path, default=REPORT_DIR / "morph_bpe_report.md")
+    args = parser.parse_args()
+
+    train_paths = args.train or [ROOT / "data" / "morph_benchmark.json"]
+    train_words = load_multiple_word_sets(train_paths)
+    eval_words = load_gold_words(args.eval)
+    standard = SimpleBPE.train(train_words, num_merges=args.merges, respect_boundaries=False)
+    morph = SimpleBPE.train(train_words, num_merges=args.merges, respect_boundaries=True)
+
+    results = [
+        evaluate_piece_tokenizer("standard_bpe_smoke", eval_words, standard.encode),
+        evaluate_piece_tokenizer("morph_bpe_constrained_smoke", eval_words, morph.encode),
+    ]
+
+    payload = {
+        "warning": "Smoke run on current gold set. Full MorphBPE/SKMT needs corpus-scale training and downstream LLM evaluation.",
+        "train_paths": [str(path) for path in train_paths],
+        "eval_path": str(args.eval),
+        "merges": {
+            "standard_bpe": standard.merges,
+            "morph_bpe": morph.merges,
+        },
+        "results": results,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    args.md_out.write_text(render_report(results), encoding="utf-8")
+
+    for result in results:
+        s = result["summary"]
+        print(f"{result['system']}: boundary_f1={s['boundary_f1']:.3f} fertility={s['fertility']:.3f} align_p={s['alignment_precision']:.3f}")
+    print(f"wrote {args.md_out}")
+    print(f"wrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/run_neural_segmenter.py
+++ b/bench/chomsky_sota2026/scripts/run_neural_segmenter.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.sota2026_utils import REPORT_DIR, boundary_prf, load_gold_words, load_multiple_word_sets
+
+
+def require_torch():
+    try:
+        import torch
+        from torch import nn
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit("PyTorch is required for neural segmenter training.") from exc
+    return torch, nn
+
+
+class BoundaryTagger:
+    def __init__(self, chars: list[str], hidden_size: int = 48) -> None:
+        torch, nn = require_torch()
+        self.torch = torch
+        self.nn = nn
+        self.char_to_id = {ch: idx + 1 for idx, ch in enumerate(chars)}
+        self.id_to_char = {idx: ch for ch, idx in self.char_to_id.items()}
+        self.model = nn.Sequential()
+        self.embedding = nn.Embedding(len(self.char_to_id) + 1, hidden_size)
+        self.encoder = nn.LSTM(hidden_size, hidden_size, batch_first=True, bidirectional=True)
+        self.classifier = nn.Linear(hidden_size * 2, 1)
+
+    def parameters(self):
+        return list(self.embedding.parameters()) + list(self.encoder.parameters()) + list(self.classifier.parameters())
+
+    def encode_word(self, word: str):
+        ids = [self.char_to_id.get(ch, 0) for ch in word]
+        return self.torch.tensor(ids, dtype=self.torch.long).unsqueeze(0)
+
+    def logits(self, word: str):
+        ids = self.encode_word(word)
+        emb = self.embedding(ids)
+        encoded, _ = self.encoder(emb)
+        return self.classifier(encoded).squeeze(0).squeeze(-1)
+
+    def predict_boundaries(self, word: str) -> set[int]:
+        self.embedding.eval()
+        self.encoder.eval()
+        self.classifier.eval()
+        with self.torch.no_grad():
+            probs = self.torch.sigmoid(self.logits(word))
+        return {idx + 1 for idx, prob in enumerate(probs[:-1]) if float(prob) >= 0.5}
+
+
+def labels_for(word: str, boundaries: set[int], torch):
+    return torch.tensor([1.0 if idx + 1 in boundaries else 0.0 for idx in range(len(word))], dtype=torch.float32)
+
+
+def split_word(word: str, boundaries: set[int]) -> list[str]:
+    pieces = []
+    start = 0
+    for boundary in sorted(boundaries):
+        pieces.append(word[start:boundary])
+        start = boundary
+    pieces.append(word[start:])
+    return [piece for piece in pieces if piece]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train a small SIGMORPHON-style neural char boundary tagger.")
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--train", type=Path, nargs="*", default=None)
+    parser.add_argument("--eval", type=Path, default=ROOT / "data" / "morph_benchmark.json")
+    parser.add_argument("--out", type=Path, default=REPORT_DIR / "neural_segmenter_results.json")
+    args = parser.parse_args()
+
+    torch, nn = require_torch()
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    train_paths = args.train or [ROOT / "data" / "morph_benchmark.json"]
+    train_words = load_multiple_word_sets(train_paths)
+    eval_words = load_gold_words(args.eval)
+    chars = sorted({ch for word in train_words for ch in word.surface})
+    tagger = BoundaryTagger(chars)
+    optimizer = torch.optim.Adam(tagger.parameters(), lr=0.03)
+    criterion = nn.BCEWithLogitsLoss()
+
+    for epoch in range(args.epochs):
+        random.shuffle(train_words)
+        total_loss = 0.0
+        for item in train_words:
+            optimizer.zero_grad()
+            logits = tagger.logits(item.surface)
+            labels = labels_for(item.surface, item.boundary_offsets, torch)
+            loss = criterion(logits, labels)
+            loss.backward()
+            optimizer.step()
+            total_loss += float(loss.detach())
+        if epoch in {0, args.epochs - 1}:
+            print(f"epoch={epoch + 1} loss={total_loss / len(train_words):.4f}")
+
+    rows = []
+    for item in eval_words:
+        predicted = tagger.predict_boundaries(item.surface)
+        precision, recall, f1 = boundary_prf(predicted, item.boundary_offsets)
+        rows.append(
+            {
+                "surface": item.surface,
+                "category": item.category,
+                "gold": list(item.pieces),
+                "predicted": split_word(item.surface, predicted),
+                "boundary_precision": precision,
+                "boundary_recall": recall,
+                "boundary_f1": f1,
+            }
+        )
+
+    summary = {
+        "system": "neural_char_boundary_tagger_smoke",
+        "train_paths": [str(path) for path in train_paths],
+        "eval_path": str(args.eval),
+        "train_cases": len(train_words),
+        "cases": len(rows),
+        "boundary_f1": sum(row["boundary_f1"] for row in rows) / len(rows),
+        "warning": "Smoke run on the tiny current gold set. This is pipeline validation, not a SOTA result.",
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps({"summary": summary, "rows": rows}, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/run_sota2026_pipeline.py
+++ b/bench/chomsky_sota2026/scripts/run_sota2026_pipeline.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(args: list[str]) -> None:
+    print("$", " ".join(args))
+    subprocess.run(args, cwd=ROOT, check=True)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the local SOTA 2026 smoke pipeline.")
+    parser.add_argument("--neural-python", default=shutil.which("python3") or sys.executable)
+    args = parser.parse_args()
+
+    py = sys.executable
+    run([py, "scripts/generate_synthetic_morph_examples.py", "--count", "100"])
+    train_paths = ["data/morph_benchmark.json", "data/synthetic_morph_examples.json"]
+    run([py, "scripts/export_sigmorphon_format.py"])
+    run([py, "scripts/evaluate_morph_segmentation.py"])
+    run([py, "scripts/run_morph_bpe.py", "--train", *train_paths])
+    run([py, "scripts/run_downstream_smoke.py", "--train", *train_paths])
+    run([args.neural_python, "scripts/run_neural_segmenter.py", "--epochs", "200", "--train", *train_paths])
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chomsky_sota2026/scripts/sota2026_utils.py
+++ b/bench/chomsky_sota2026/scripts/sota2026_utils.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_PATH = ROOT / "data" / "morph_benchmark.json"
+REPORT_DIR = ROOT / "reports"
+
+
+@dataclass(frozen=True)
+class SegmentedWord:
+    surface: str
+    pieces: tuple[str, ...]
+    category: str = ""
+
+    @property
+    def boundary_offsets(self) -> set[int]:
+        offsets = set()
+        cursor = 0
+        for piece in self.pieces[:-1]:
+            cursor += len(piece)
+            offsets.add(cursor)
+        return offsets
+
+
+def load_gold_words(path: Path = BENCHMARK_PATH) -> list[SegmentedWord]:
+    benchmark = json.loads(path.read_text(encoding="utf-8"))
+    return [
+        SegmentedWord(
+            surface=case["surface"],
+            pieces=tuple(piece for piece, _ in case["gold"]),
+            category=case["category"],
+        )
+        for case in benchmark["cases"]
+    ]
+
+
+def load_multiple_word_sets(paths: list[Path]) -> list[SegmentedWord]:
+    words: list[SegmentedWord] = []
+    for path in paths:
+        words.extend(load_gold_words(path))
+    return words
+
+
+def boundary_prf(predicted: set[int], gold: set[int]) -> tuple[float, float, float]:
+    if not predicted and not gold:
+        return 1.0, 1.0, 1.0
+    tp = len(predicted & gold)
+    precision = tp / len(predicted) if predicted else 0.0
+    recall = tp / len(gold) if gold else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return precision, recall, f1
+
+
+def pieces_to_boundaries(pieces: list[str] | tuple[str, ...]) -> set[int]:
+    offsets = set()
+    cursor = 0
+    for piece in pieces[:-1]:
+        cursor += len(piece)
+        offsets.add(cursor)
+    return offsets
+
+
+def avg(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+@dataclass
+class BPESymbol:
+    text: str
+    start: int
+    end: int
+
+
+class SimpleBPE:
+    def __init__(self, merges: list[tuple[str, str]], name: str) -> None:
+        self.merges = merges
+        self.name = name
+
+    @staticmethod
+    def train(words: list[SegmentedWord], num_merges: int, respect_boundaries: bool) -> "SimpleBPE":
+        sequences = []
+        for word in words:
+            boundary_offsets = word.boundary_offsets
+            seq = [BPESymbol(ch, idx, idx + 1) for idx, ch in enumerate(word.surface)]
+            sequences.append((seq, boundary_offsets))
+
+        merges: list[tuple[str, str]] = []
+        for _ in range(num_merges):
+            counts: Counter[tuple[str, str]] = Counter()
+            for seq, boundary_offsets in sequences:
+                for left, right in zip(seq, seq[1:]):
+                    if respect_boundaries and any(left.start < boundary < right.end for boundary in boundary_offsets):
+                        continue
+                    counts[(left.text, right.text)] += 1
+            if not counts:
+                break
+            pair, _ = counts.most_common(1)[0]
+            merges.append(pair)
+            sequences = [(merge_sequence(seq, pair), boundary_offsets) for seq, boundary_offsets in sequences]
+
+        return SimpleBPE(merges, "morph_bpe" if respect_boundaries else "standard_bpe")
+
+    def encode(self, word: str) -> list[str]:
+        seq = [BPESymbol(ch, idx, idx + 1) for idx, ch in enumerate(word)]
+        for pair in self.merges:
+            seq = merge_sequence(seq, pair)
+        return [symbol.text for symbol in seq]
+
+
+def merge_sequence(seq: list[BPESymbol], pair: tuple[str, str]) -> list[BPESymbol]:
+    merged = []
+    idx = 0
+    while idx < len(seq):
+        if idx + 1 < len(seq) and (seq[idx].text, seq[idx + 1].text) == pair:
+            merged.append(BPESymbol(seq[idx].text + seq[idx + 1].text, seq[idx].start, seq[idx + 1].end))
+            idx += 2
+        else:
+            merged.append(seq[idx])
+            idx += 1
+    return merged
+
+
+def evaluate_piece_tokenizer(name: str, words: list[SegmentedWord], encode) -> dict:
+    rows = []
+    for word in words:
+        pieces = encode(word.surface)
+        pred_boundaries = pieces_to_boundaries(pieces)
+        gold_boundaries = word.boundary_offsets
+        precision, recall, f1 = boundary_prf(pred_boundaries, gold_boundaries)
+        rows.append(
+            {
+                "surface": word.surface,
+                "category": word.category,
+                "gold": list(word.pieces),
+                "predicted": pieces,
+                "boundary_precision": precision,
+                "boundary_recall": recall,
+                "boundary_f1": f1,
+                "fertility": len(pieces),
+                "alignment_precision": precision,
+                "alignment_recall": recall,
+            }
+        )
+
+    category_rows: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        category_rows[row["category"]].append(row)
+
+    return {
+        "system": name,
+        "summary": {
+            "cases": len(rows),
+            "boundary_f1": avg([row["boundary_f1"] for row in rows]),
+            "fertility": avg([row["fertility"] for row in rows]),
+            "alignment_precision": avg([row["alignment_precision"] for row in rows]),
+            "alignment_recall": avg([row["alignment_recall"] for row in rows]),
+        },
+        "categories": {
+            category: {
+                "cases": len(items),
+                "boundary_f1": avg([row["boundary_f1"] for row in items]),
+                "fertility": avg([row["fertility"] for row in items]),
+                "alignment_precision": avg([row["alignment_precision"] for row in items]),
+                "alignment_recall": avg([row["alignment_recall"] for row in items]),
+            }
+            for category, items in sorted(category_rows.items())
+        },
+        "rows": rows,
+    }
+
+
+class BigramLM:
+    def __init__(self) -> None:
+        self.unigram: Counter[str] = Counter()
+        self.bigram: Counter[tuple[str, str]] = Counter()
+        self.vocab: set[str] = set()
+
+    def fit(self, sequences: list[list[str]]) -> None:
+        for sequence in sequences:
+            tokens = ["<s>", *sequence, "</s>"]
+            self.vocab.update(tokens)
+            self.unigram.update(tokens[:-1])
+            self.bigram.update(zip(tokens, tokens[1:]))
+
+    def perplexity(self, sequences: list[list[str]]) -> float:
+        vocab_size = max(1, len(self.vocab))
+        nll = 0.0
+        count = 0
+        for sequence in sequences:
+            tokens = ["<s>", *sequence, "</s>"]
+            for left, right in zip(tokens, tokens[1:]):
+                prob = (self.bigram[(left, right)] + 1) / (self.unigram[left] + vocab_size)
+                nll -= math.log(prob)
+                count += 1
+        return math.exp(nll / count) if count else float("inf")

--- a/public/data/chomsky-sota2026/data/morph_benchmark.json
+++ b/public/data/chomsky-sota2026/data/morph_benchmark.json
@@ -1,0 +1,91 @@
+{
+  "name": "Polish Morphological Boundary Benchmark",
+  "version": "0.1.0",
+  "description": "Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.",
+  "cases": [
+    {
+      "id": "adv_comp_bardziej",
+      "category": "adverb_comparative",
+      "surface": "bardziej",
+      "expected_morph_tags": ["adv:com"],
+      "gold": [["bardz", "ROOT_ALLOMORPH"], ["iej", "ADV_COMPARATIVE"]]
+    },
+    {
+      "id": "adv_comp_najbardziej",
+      "category": "adverb_comparative",
+      "surface": "najbardziej",
+      "expected_morph_tags": ["adv:sup"],
+      "gold": [["naj", "PREFIX"], ["bardz", "ROOT_ALLOMORPH"], ["iej", "ADV_COMPARATIVE"]]
+    },
+    {
+      "id": "pron_kolwiek_kogo",
+      "category": "indefinite_pronoun",
+      "surface": "kogokolwiek",
+      "expected_morph_tags": ["subst:sg:gen", "subst:sg:acc"],
+      "gold": [["kogo", "PRONOUN_BASE"], ["kolwiek", "INDEF_PARTICLE"]]
+    },
+    {
+      "id": "pron_kolwiek_czego",
+      "category": "indefinite_pronoun",
+      "surface": "czegokolwiek",
+      "expected_morph_tags": ["subst:sg:gen", "subst:sg:acc"],
+      "gold": [["czego", "PRONOUN_BASE"], ["kolwiek", "INDEF_PARTICLE"]]
+    },
+    {
+      "id": "verb_pref_przemierzaja",
+      "category": "prefixed_verb_theme",
+      "surface": "przemierzają",
+      "expected_morph_tags": ["fin:pl:ter"],
+      "gold": [["prze", "PREFIX"], ["mierz", "ROOT"], ["aj", "VERB_THEME"], ["ą", "PRES_3PL"]]
+    },
+    {
+      "id": "verb_pref_odmierzaja",
+      "category": "prefixed_verb_theme",
+      "surface": "odmierzają",
+      "expected_morph_tags": ["fin:pl:ter"],
+      "gold": [["od", "PREFIX"], ["mierz", "ROOT"], ["aj", "VERB_THEME"], ["ą", "PRES_3PL"]]
+    },
+    {
+      "id": "adj_stem_ext_innego",
+      "category": "adjective_stem_extension",
+      "surface": "innego",
+      "expected_morph_tags": ["adj:sg:gen", "adj:sg:acc"],
+      "gold": [["in", "ROOT"], ["n", "STEM_EXT"], ["ego", "GEN_SG_MN_ADJ"]]
+    },
+    {
+      "id": "adj_stem_ext_czynnego",
+      "category": "adjective_stem_extension",
+      "surface": "czynnego",
+      "expected_morph_tags": ["adj:sg:gen", "adj:sg:acc"],
+      "gold": [["czyn", "ROOT"], ["n", "STEM_EXT"], ["ego", "GEN_SG_MN_ADJ"]]
+    },
+    {
+      "id": "noun_alt_psem",
+      "category": "nominal_root_alternation",
+      "surface": "psem",
+      "expected_morph_tags": ["subst:sg:inst"],
+      "gold": [["ps", "ROOT_ALLOMORPH"], ["em", "INST_SG"]]
+    },
+    {
+      "id": "noun_alt_psu",
+      "category": "nominal_root_alternation",
+      "surface": "psu",
+      "expected_morph_tags": ["subst:sg:dat"],
+      "gold": [["ps", "ROOT_ALLOMORPH"], ["u", "GEN_LOC_SG"]]
+    },
+    {
+      "id": "noun_alt_rece",
+      "category": "nominal_root_alternation",
+      "surface": "ręce",
+      "expected_morph_tags": ["subst:sg:dat", "subst:sg:loc", "subst:pl:nom", "subst:pl:acc"],
+      "gold": [["ręc", "ROOT_ALLOMORPH"], ["e", "NOM_ACC_PL"]]
+    },
+    {
+      "id": "verb_allomorph_przyszlismy",
+      "category": "verbal_root_alternation",
+      "surface": "przyszliśmy",
+      "expected_morph_tags": ["praet:pl"],
+      "gold": [["przy", "PREFIX"], ["sz", "ROOT_ALLOMORPH"], ["liśmy", "PAST_1PL"]]
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/data/polish_samples.txt
+++ b/public/data/chomsky-sota2026/data/polish_samples.txt
@@ -1,0 +1,10 @@
+Przyszliśmy wcześniej, ponieważ najprawdopodobniej będzie padało.
+Niepodległościowego przemówienia wysłuchali nauczyciele, uczniowie i urzędnicy.
+Zażółć gęślą jaźń, a później sprawdź, czy wszystkie znaki działają.
+Rozpoznawalność przedsiębiorstw wzrosła po przeprowadzeniu restrukturyzacji.
+Najmniejszymi łyżeczkami mieszaliśmy gorącą herbatę z miodem.
+Dziewięćdziesięciopięcioletnia archiwistka opowiadała o przedwojennych dokumentach.
+W Szczebrzeszynie chrząszcz brzmi w trzcinie i mieszkańcy dobrze to wiedzą.
+Przeanalizowalibyśmy najtrudniejsze przypadki odmiany, gdyby wystarczyło czasu.
+Bezpieczeństwo użytkowników zależy od odpowiedzialnego projektowania interfejsów.
+Książkami, notatkami i załącznikami zarządzaliśmy w międzywydziałowym sekretariacie.

--- a/public/data/chomsky-sota2026/data/synthetic_morph_examples.json
+++ b/public/data/chomsky-sota2026/data/synthetic_morph_examples.json
@@ -1,0 +1,2592 @@
+{
+  "name": "Synthetic Polish Morphology Stress Set",
+  "version": "0.1.0",
+  "description": "Random template-generated examples for pipeline stress testing. These are not manually verified gold examples.",
+  "seed": 2026,
+  "cases": [
+    {
+      "id": "synthetic_001",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "poszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_002",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "oczem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_003",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kiedykolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kiedy",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_004",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziece",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_005",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "siennego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "sien",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_006",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "biernego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_007",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_008",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "szybciej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "szybc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_009",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "innego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "in",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_010",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "rodzinnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "rodzin",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_011",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "wolniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "woln",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_012",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "częściej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "częśc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_013",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziecu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_014",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "rzadziej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "rzadz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_015",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "czymkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "czym",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_016",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "powołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_017",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "szkolnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "szkol",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_018",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_019",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludzem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_020",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "prawnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "praw",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_021",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludzu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_022",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóżu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_023",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ludze",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ludz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_024",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "pse",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_025",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "komukolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "komu",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_026",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_027",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "jakkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "jak",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_028",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "czegokolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "czego",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_029",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "gminnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "gmin",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_030",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóże",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_031",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "dziennego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "dzien",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_032",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ocze",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_033",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "trudniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "trudn",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_034",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przepisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_035",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "czynnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "czyn",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_036",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_037",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kimkolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kim",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_038",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_039",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "kogokolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "kogo",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_040",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "daleiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "dale",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_041",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozpisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_042",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_043",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "dziecem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "dziec",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_044",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręce",
+      "expected_morph_tags": [
+        "subst:pl:nom",
+        "subst:pl:acc"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "e",
+          "NOM_ACC_PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_045",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_046",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wypisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_047",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_048",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręcem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_049",
+      "split": "synthetic",
+      "category": "synthetic_indefinite_pronoun",
+      "surface": "gdziekolwiek",
+      "expected_morph_tags": [],
+      "gold": [
+        [
+          "gdzie",
+          "PRONOUN_BASE"
+        ],
+        [
+          "kolwiek",
+          "INDEF_PARTICLE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_050",
+      "split": "synthetic",
+      "category": "synthetic_adjective_stem_extension",
+      "surface": "winnego",
+      "expected_morph_tags": [
+        "adj:sg:gen",
+        "adj:sg:acc"
+      ],
+      "gold": [
+        [
+          "win",
+          "ROOT"
+        ],
+        [
+          "n",
+          "STEM_EXT"
+        ],
+        [
+          "ego",
+          "GEN_SG_MN_ADJ"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_051",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "bliżiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "bliż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_052",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_053",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_054",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "popisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_055",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zaszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_056",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przewołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_057",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "psu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_058",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "mocniej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "mocn",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_059",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przebierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_060",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeliczają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_061",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_062",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozmierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_063",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_064",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dostawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_065",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "bardziej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "bardz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_066",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przenosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_067",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "oczu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ocz",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_068",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "przeczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "prze",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_069",
+      "split": "synthetic",
+      "category": "synthetic_adverb_comparative",
+      "surface": "łatwiej",
+      "expected_morph_tags": [
+        "adv:com"
+      ],
+      "gold": [
+        [
+          "łatw",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "iej",
+          "ADV_COMPARATIVE"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_070",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "nóżem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "nóż",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_071",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_072",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "rozbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "roz",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_073",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dobierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_074",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "psem",
+      "expected_morph_tags": [
+        "subst:sg:inst"
+      ],
+      "gold": [
+        [
+          "ps",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "em",
+          "INST_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_075",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_076",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "policzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "licz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_077",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_078",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "ponosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_079",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_080",
+      "split": "synthetic",
+      "category": "synthetic_nominal_allomorph",
+      "surface": "ręcu",
+      "expected_morph_tags": [
+        "subst:sg:gen",
+        "subst:sg:loc",
+        "subst:sg:dat"
+      ],
+      "gold": [
+        [
+          "ręc",
+          "ROOT_ALLOMORPH"
+        ],
+        [
+          "u",
+          "GEN_LOC_SG"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_081",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zawołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_082",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wykrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_083",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zabierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_084",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "doszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_085",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_086",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wymierzają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "mierz",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_087",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zanosają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "nos",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_088",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zaczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_089",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podbierają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "bier",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_090",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odwołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_091",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wyczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_092",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "doczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_093",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_094",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "odstawają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "od",
+          "PREFIX"
+        ],
+        [
+          "staw",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_095",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "dowołają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "do",
+          "PREFIX"
+        ],
+        [
+          "woł",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_096",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "podczytają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "pod",
+          "PREFIX"
+        ],
+        [
+          "czyt",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_097",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "nadkrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "nad",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_098",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "zapisają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "za",
+          "PREFIX"
+        ],
+        [
+          "pis",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_099",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "wyszukają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "wy",
+          "PREFIX"
+        ],
+        [
+          "szuk",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    },
+    {
+      "id": "synthetic_100",
+      "split": "synthetic",
+      "category": "synthetic_prefixed_verb",
+      "surface": "pokrojają",
+      "expected_morph_tags": [
+        "fin:pl:ter"
+      ],
+      "gold": [
+        [
+          "po",
+          "PREFIX"
+        ],
+        [
+          "kroj",
+          "ROOT"
+        ],
+        [
+          "aj",
+          "VERB_THEME"
+        ],
+        [
+          "ą",
+          "PRES_3PL"
+        ]
+      ],
+      "provenance": "synthetic_template_generator",
+      "verified": false
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/docs/polish_morpheme_benchmark_protocol.md
+++ b/public/data/chomsky-sota2026/docs/polish_morpheme_benchmark_protocol.md
@@ -1,0 +1,209 @@
+# Polish Morpheme Boundary Benchmark Protocol
+
+## Goal
+
+This benchmark is not a tokenizer demo. It is a Polish gold-standard morpheme-boundary benchmark designed to test whether morphology-aware tokenization helps Polish language modeling.
+
+The core research question is deliberately empirical:
+
+> Does Polish morphology-aware tokenization improve intrinsic tokenizer quality and downstream language-model behavior over strong BPE-style baselines?
+
+A negative result is still valuable. For fusional languages, literature does not make the downstream uplift obvious.
+
+## Positioning
+
+The benchmark should not compete with SOTA morpheme segmenters by hand-written rules. The relevant comparison axes are:
+
+- neural morpheme segmentation quality,
+- tokenizer morphology alignment and fertility,
+- downstream language-model evidence.
+
+The intended contribution is the Polish evaluation resource and protocol:
+
+- Polish is absent from the SIGMORPHON 2022 morpheme segmentation languages, while Czech and Russian are present.
+- Polish has high-value fusional edge cases: root allomorphy, palatalization, stem extensions, suppletion, syncretism, and prefixal verbs.
+- Morfeusz2 and Concraft-pl are strong form-analysis baselines, but they do not directly provide morpheme boundaries.
+
+## Systems To Compare
+
+### Form Analyzers
+
+These systems are evaluated for coverage and tag disambiguation, not boundary F1 unless an additional boundary adapter is supplied.
+
+- `morfeusz2`: lemma, POS, morphosyntactic tags, ambiguity.
+- `concraft-pl`: contextual disambiguation over Morfeusz analyses.
+
+Metrics:
+
+- recognized rate,
+- expected tag match,
+- ambiguity count before and after disambiguation,
+- coverage by category.
+
+### Morpheme Segmenters
+
+These systems are evaluated on gold morpheme boundaries.
+
+- supervised char-level seq2seq segmenter trained on the benchmark train split,
+- SIGMORPHON-style neural baseline where available,
+- current `polish_morph_current` prototype as a weak baseline,
+- phoneme-syllable fallback as a control.
+
+Metrics:
+
+- boundary precision,
+- boundary recall,
+- boundary F1,
+- exact segmentation,
+- role accuracy as diagnostic only.
+
+### LLM Tokenizers
+
+These systems are evaluated as tokenizers, not as linguistic analyzers.
+
+- standard BPE,
+- WordPiece or Unigram where available,
+- `tiktoken_cl100k` as a widely used production BPE reference,
+- MorphBPE-style morphology-aware BPE,
+- SKMT-style root-preserving BPE adapted to Polish,
+- SuperBPE / BoundlessBPE / PickyBPE-style compression-oriented baselines where implemented.
+
+Metrics:
+
+- fertility: tokens per whitespace word,
+- morphological alignment precision: proportion of tokenizer boundaries that match gold morpheme boundaries,
+- morphological alignment recall: proportion of gold morpheme boundaries recovered by tokenizer boundaries,
+- MorphBPE-style consistency metrics when implemented,
+- vocabulary size and token frequency balance.
+
+## Annotation Format
+
+The canonical JSON format stores typed morpheme spans:
+
+```json
+{
+  "id": "noun_alt_psem",
+  "split": "dev",
+  "category": "nominal_root_alternation",
+  "surface": "psem",
+  "lemma": "pies",
+  "expected_morph_tags": ["subst:sg:inst"],
+  "gold": [
+    ["ps", "ROOT_ALLOMORPH"],
+    ["em", "INST_SG"]
+  ]
+}
+```
+
+Required fields:
+
+- `id`: stable unique case identifier,
+- `surface`: surface word form,
+- `category`: linguistic phenomenon,
+- `gold`: ordered `[text, role]` morpheme sequence.
+
+Recommended fields:
+
+- `split`: `train`, `dev`, `test`, or `holdout`,
+- `lemma`: canonical lemma,
+- `expected_morph_tags`: acceptable Morfeusz/Concraft tag prefixes,
+- `notes`: annotator rationale for controversial boundaries.
+
+Boundary metrics use only `text` spans. Role labels are diagnostic and should not dominate leaderboard ranking.
+
+## SIGMORPHON-Compatible Export
+
+For word-level segmentation, export one word per line:
+
+```text
+psem    ps @@ em
+przemierzają    prze @@ mierz @@ aj @@ ą
+```
+
+Roles can be exported as an auxiliary TSV:
+
+```text
+psem    ps|ROOT_ALLOMORPH @@ em|INST_SG
+```
+
+The role-free export is used for cross-system morpheme segmentation evaluation. The role export is used for Polish-specific error analysis.
+
+## Gold Set Categories
+
+The benchmark should be balanced by phenomenon, not corpus frequency. The first useful target is 1,000 held-out forms plus train/dev material for supervised baselines.
+
+Recommended target counts:
+
+| category | target test cases | examples | rationale |
+| --- | ---: | --- | --- |
+| nominal root alternation | 120 | `pies -> ps-`, `ręka -> ręc-` | Core fusional boundary challenge. |
+| verbal root alternation | 120 | `iść -> szedł/przyszliśmy` | Breaks naive stem stability. |
+| prefixal verbs | 120 | `prze-mierz-aj-ą` | Tests prefix/root/theme boundaries. |
+| stem extensions | 80 | `in-n-ego`, `czyn-n-ego` | Distinguishes root from stem material. |
+| palatalization | 100 | `ręka/ręce`, `noga/nodze` | Polish-specific morphophonology. |
+| suppletion | 80 | `człowiek/ludzie`, `rok/lata` | Cannot be solved by suffix stripping. |
+| indefinite pronouns | 60 | `kogo-kolwiek`, `czego-kolwiek` | Compound-like pronoun morphology. |
+| adverb comparison | 60 | `bardz-iej`, `szybc-iej` | Category error trap for adjectival endings. |
+| derivational suffixes | 120 | `naucz-yciel`, `mieszka-niec` | Tests derivation beyond inflection. |
+| compounds / numerals | 80 | `pięcio-let-ni`, `między-wydział-ow-y` | Long forms and internal boundaries. |
+| syncretic endings | 80 | forms with shared endings | Tests ambiguity and tag sensitivity. |
+| named/common edge cases | 80 | proper names, rare forms | Measures robustness without overfitting. |
+
+## Splits
+
+Use leakage-resistant splits:
+
+- `train`: for supervised segmenter and MorphBPE boundary training.
+- `dev`: for tokenizer hyperparameters and benchmark iteration.
+- `test`: locked public leaderboard split.
+- `holdout`: private or delayed-release forms with related lemmas held out.
+
+For allomorphy categories, split by lemma family, not by surface form. If `pies/psem/psu` appears in train, the test split should contain a different alternation family.
+
+## Intrinsic Evaluation
+
+Report all of the following:
+
+- boundary precision/recall/F1,
+- fertility,
+- morphological alignment precision/recall,
+- vocabulary size,
+- token frequency entropy or Gini coefficient,
+- per-category breakdown,
+- failure examples.
+
+Do not lead with token accuracy. Token accuracy hides whether wrong cuts cross true morpheme boundaries.
+
+## Extrinsic Evaluation
+
+Intrinsic alignment is not enough. The downstream protocol should include:
+
+- tokenizer training on the same Polish corpus,
+- fixed vocabulary budget,
+- fixed model architecture and training budget,
+- baseline BPE vs morphology-aware BPE vs compression-oriented BPE,
+- perplexity on held-out Polish text,
+- at least one morphosyntactic task from an Open PL LLM Leaderboard-style suite,
+- at least one paradigm/generalization probe.
+
+Minimum defensible experiment:
+
+1. Train three tokenizers on identical corpus slices: standard BPE, MorphBPE-style Polish, and compression-oriented BPE.
+2. Train identical small LMs or adapters under the same token budget.
+3. Report fertility/alignment plus perplexity and morphosyntactic task score.
+4. Analyze whether alignment predicts downstream gains for Polish.
+
+## Publication Claim Boundary
+
+Defensible claims:
+
+- Polish lacks a public SIGMORPHON-style morpheme-boundary benchmark covering fusional edge cases.
+- Morfeusz2/Concraft solve form analysis, not boundary-constrained LLM tokenization.
+- Morphological alignment and fertility can be measured directly for Polish tokenizers.
+- Downstream uplift for Polish is an empirical question, not an assumption.
+
+Claims to avoid until measured:
+
+- morphology-aware tokenization is SOTA for Polish LLM downstream quality,
+- higher morpheme alignment necessarily improves all Polish tasks,
+- rule-based segmentation can compete with neural morpheme segmenters.

--- a/public/data/chomsky-sota2026/docs/sota_2026_matrix.md
+++ b/public/data/chomsky-sota2026/docs/sota_2026_matrix.md
@@ -1,0 +1,191 @@
+# SOTA 2026 Baseline Matrix
+
+Last checked: 2026-06-14.
+
+This project should start from the 2026 tokenization landscape, not from hand-written segmentation rules.
+
+## Research Axes
+
+There are three different tasks that must not be collapsed into one leaderboard:
+
+1. **Morpheme segmentation**: predict morpheme boundaries for a word.
+2. **Morphosyntactic analysis/disambiguation**: identify lemma, POS, morphosyntactic tag, and contextually correct interpretation.
+3. **LLM tokenization**: produce a vocabulary and segmentation that improves compression, training dynamics, and downstream quality.
+
+The Polish contribution should be a benchmark and evaluation protocol crossing these axes, not a claim that one rule-based tokenizer is SOTA.
+
+## Current Baselines
+
+| system family | role in this project | why it matters | implementation status |
+| --- | --- | --- | --- |
+| SIGMORPHON-style neural char seq2seq segmenters | SOTA morpheme segmentation baseline | Strong supervised morpheme segmenters are the real segmentation competition, not Morfessor-era baselines. SIGMORPHON 2022 reports 97.29 average F1 for the best word-level system over 9 languages including Czech and Russian. | Not implemented. Needs train/dev/test export and training adapter. |
+| Morfeusz2 | Polish form-analysis baseline | Provides Polish lemma/POS/tag coverage and ambiguity graph, but not morpheme boundaries. | Implemented as analyzer coverage in benchmark runner. |
+| Concraft-pl | Polish disambiguation baseline | Contextual disambiguation over Morfeusz analyses; needed for sentence-level gold analysis. | Slot present; not installed locally. |
+| MorphBPE | Main morphology-aware BPE baseline | Constrains BPE merges with morpheme boundaries while preserving LLM pipeline compatibility. | Not implemented. Needs adapter around gold boundary data. |
+| SKMT-style root-preserving BPE | Closest Slavic precedent | Slovak morphology+BPE template; useful structure for a Polish PMT paper. | Not implemented. |
+| Unigram tokenizer | Algorithmic counter-baseline | Recent work argues algorithm choice can matter more than morphological alignment. | Not implemented. |
+| tiktoken/cl100k | Production BPE reference | Useful real-world BPE fragmentation baseline. | Implemented. |
+| SuperBPE / BoundlessBPE | Compression-oriented counter-baseline | Tests whether compression/superwords beat morphology for downstream efficiency. | Not implemented. |
+| Morfessor2 / WordPiece / ULM as segmentation baselines | Historical lower baselines | SIGMORPHON 2022 shows these are dramatically weaker for morpheme segmentation than the best neural systems. They are useful only to show that old statistical segmentation is not enough. | Not implemented; low priority. |
+
+## Non-Negotiable SOTA Point
+
+The current rule-based prototype is not a SOTA morpheme segmenter. It should stay in the benchmark as `polish_morph_current`, a weak and interpretable baseline.
+
+The SOTA segmentation comparison must be against neural, supervised, character-level morpheme segmenters in the SIGMORPHON line. The important 2022 reference point is:
+
+- word-level task: 5 million words, 9 languages, including Czech and Russian,
+- 13 systems from 7 teams,
+- best system average: 97.29 F1,
+- English to Latin range: 93.84 to 99.38 F1,
+- sentence-level task: best systems outperform BPE, ULM, and Morfessor2 by 30.71 absolute points.
+
+Implication for this project:
+
+- `-kolwiek`, `-iej`, `-ają` rules are useful as failure labels and sanity checks.
+- They are not the research contribution.
+- The research contribution is a Polish gold benchmark plus a comparison that includes neural segmenters, Polish analyzers, MorphBPE-style tokenizers, and downstream LLM evidence.
+
+## What To Measure
+
+### Intrinsic Morpheme Segmentation
+
+- boundary precision,
+- boundary recall,
+- boundary F1,
+- exact segmentation as secondary diagnostic,
+- per-category breakdown.
+
+### Intrinsic LLM Tokenizer Quality
+
+- fertility: tokens per whitespace word,
+- morphological alignment precision,
+- morphological alignment recall,
+- vocabulary size,
+- token frequency balance,
+- MorphBPE-style consistency metrics when adapter is implemented.
+
+### Extrinsic LLM Evidence
+
+- held-out Polish perplexity under fixed model/training budget,
+- morphosyntactic probe task,
+- Open PL LLM Leaderboard-style task subset,
+- correlation between intrinsic alignment and downstream score.
+
+## 2026 Research Interpretation
+
+### What Seems Established
+
+- Pure morpheme segmentation SOTA is neural/supervised, especially char-level seq2seq style systems.
+- Classical unsupervised/statistical segmentation baselines such as Morfessor-style approaches are not enough for a SOTA claim.
+- A rule-based Polish prototype cannot be positioned as SOTA; it is a weak baseline and debugging surface.
+- Morphology-aware BPE is an active and credible line because it changes tokenizer training while keeping LLM pipeline compatibility.
+- For LLM quality, morphological alignment is only one axis; it must be tested against algorithm choice, compression, vocabulary distribution, and downstream tasks.
+
+### What Is Not Established For Polish
+
+- Whether morphology-aware tokenization improves Polish downstream LLM quality.
+- Whether a Polish MorphBPE/SKMT-style tokenizer beats Unigram or compression-oriented tokenizers under the same budget.
+- Which Polish morphology categories are most responsible for BPE boundary failures.
+- Whether Morfeusz2 + Concraft disambiguation is enough to create reliable boundary constraints without a manually curated morpheme-boundary lexicon.
+
+## Recommended 2026 Experiment
+
+### Phase 1: Gold Benchmark
+
+Build a SIGMORPHON-compatible Polish morpheme-boundary dataset:
+
+- 1,000 locked test forms,
+- train/dev split for supervised segmenters,
+- lemma-family holdout for allomorphy and suppletion,
+- categories listed in `docs/polish_morpheme_benchmark_protocol.md`.
+
+Deliverables:
+
+- `data/morph_benchmark.json`,
+- SIGMORPHON-style TSV exports,
+- inter-annotator agreement once multiple annotators exist,
+- per-category leaderboard.
+
+### Phase 2: Baseline Matrix
+
+Run:
+
+- Morfeusz2 analyzer coverage,
+- Concraft-pl disambiguation where installed,
+- current weak segmenter,
+- neural seq2seq segmenter,
+- Morfessor2/WordPiece/ULM only as historical lower baselines if cheap,
+- standard BPE,
+- Unigram,
+- MorphBPE-style BPE,
+- SKMT-style root-preserving BPE,
+- SuperBPE/BoundlessBPE if available.
+
+Deliverables:
+
+- intrinsic segmentation table,
+- tokenizer fertility/alignment table,
+- failure taxonomy.
+
+Current runnable smoke commands:
+
+```bash
+python3 scripts/generate_synthetic_morph_examples.py --count 100
+.venv/bin/python scripts/run_morph_bpe.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
+python3 scripts/run_neural_segmenter.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
+```
+
+The neural and MorphBPE scripts are smoke implementations for validating the research pipeline. They are not claimed as final SOTA systems.
+
+### Phase 3: Downstream Check
+
+Train small Polish LMs or adapters with identical budget:
+
+- standard BPE,
+- Unigram,
+- Polish MorphBPE,
+- compression-oriented BPE.
+
+Report:
+
+- training tokens and wall-clock,
+- validation perplexity,
+- Polish morphosyntactic probe,
+- Open PL-style task score,
+- relation between alignment and downstream quality.
+
+Current runnable downstream smoke:
+
+```bash
+.venv/bin/python scripts/run_downstream_smoke.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
+```
+
+This uses a cheap bigram LM as a wiring check. The publishable version must replace it with fixed-budget Polish LM training.
+
+## Claim Discipline
+
+Safe claim now:
+
+> We are building a Polish benchmark and protocol to test whether morphology-aware tokenization helps Polish LLMs.
+
+Unsafe claim now:
+
+> A Polish morphological tokenizer is SOTA for Polish LLMs.
+
+Target claim after experiments:
+
+> Under fixed training conditions, Polish morphology-aware BPE improves or does not improve downstream Polish LLM quality relative to standard BPE, Unigram, and compression-oriented tokenizers; the benchmark identifies which morphology categories drive the result.
+
+## Source Pointers
+
+- SIGMORPHON ACL Anthology index: https://aclanthology.org/sigs/sigmorphon/
+- SIGMORPHON 2022 Shared Task on Morpheme Segmentation: https://aclanthology.org/2022.sigmorphon-1.11/
+- MorphBPE: https://openreview.net/forum?id=d8WDMqDdky and https://arxiv.org/abs/2502.00894
+- Rethinking Tokenization for Rich Morphology: https://aclanthology.org/2025.ijcnlp-srw.20/ and https://arxiv.org/abs/2508.08424
+- MorphScore 70 languages: https://arxiv.org/abs/2507.06378
+- SKMT / Slovak Morphological Tokenizer: https://pmc.ncbi.nlm.nih.gov/articles/PMC11622830/
+- SuperBPE: https://superbpe.github.io/
+- Faster Superword Tokenization / BoundlessBPE and SuperBPE: https://arxiv.org/abs/2604.05192
+- Morfeusz2: https://morfeusz.sgjp.pl/doc/about/en
+- Concraft-pl: https://zil.ipipan.waw.pl/Concraft

--- a/public/data/chomsky-sota2026/reports/downstream_smoke_results.json
+++ b/public/data/chomsky-sota2026/reports/downstream_smoke_results.json
@@ -1,0 +1,30 @@
+{
+  "results": [
+    {
+      "system": "standard_bpe_smoke",
+      "train_words": 112,
+      "eval_words": 12,
+      "train_paths": [
+        "data/morph_benchmark.json",
+        "data/synthetic_morph_examples.json"
+      ],
+      "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+      "eval_bigram_perplexity": 24.94584478810969,
+      "eval_fertility": 3.0,
+      "warning": "Bigram smoke test only. Replace with fixed-budget Polish LM pretraining for publishable downstream proof."
+    },
+    {
+      "system": "morph_bpe_constrained_smoke",
+      "train_words": 112,
+      "eval_words": 12,
+      "train_paths": [
+        "data/morph_benchmark.json",
+        "data/synthetic_morph_examples.json"
+      ],
+      "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+      "eval_bigram_perplexity": 19.599544846844733,
+      "eval_fertility": 3.1666666666666665,
+      "warning": "Bigram smoke test only. Replace with fixed-budget Polish LM pretraining for publishable downstream proof."
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/reports/morph_benchmark_report.md
+++ b/public/data/chomsky-sota2026/reports/morph_benchmark_report.md
@@ -1,0 +1,153 @@
+# Polish Morphological Boundary Benchmark v0.1.0
+
+Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.
+
+## Summary
+
+| system | cases | boundary F1 | fertility | morph alignment P | morph alignment R | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| polish_morph_current | 12 | 0.833 | 2.583 | 0.833 | 0.833 | 0.000 |
+| phoneme_syllable_baseline | 12 | 0.361 | 2.833 | 0.278 | 0.389 | 1.000 |
+| tiktoken_cl100k | 12 | 0.325 | 3.583 | 0.340 | 0.333 | 0.000 |
+
+## Diagnostics
+
+| system | exact segments | exact roles | source distribution |
+| --- | ---: | ---: | --- |
+| polish_morph_current | 0.833 | 0.750 | `{'rule:adverb_comparative': 2, 'rule:indefinite_pronoun': 2, 'rule:present_3pl_aja': 2, 'rule:adjective_stem_extension': 2, 'heuristic': 3, 'ladder_entry': 1}` |
+| phoneme_syllable_baseline | 0.000 | 0.000 | `{'phoneme_syllable': 12}` |
+| tiktoken_cl100k | 0.083 | 0.000 | `{'tiktoken_cl100k': 12}` |
+
+## Analyzer Coverage
+
+| analyzer | status | recognized | expected tag match | note |
+| --- | --- | ---: | ---: | --- |
+| morfeusz2 | available | 1.000 | 1.000 | form analyzer baseline; does not provide morpheme boundaries |
+| concraft-pl | missing | 0.000 | 0.000 | not installed in this environment |
+
+## Category Breakdown
+
+### polish_morph_current
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 1.000 | 3.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| adverb_comparative | 2 | 1.000 | 2.500 | 1.000 | 1.000 | 1.000 | 0.000 |
+| indefinite_pronoun | 2 | 1.000 | 2.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| nominal_root_alternation | 3 | 0.333 | 1.667 | 0.333 | 0.333 | 0.000 | 0.000 |
+| prefixed_verb_theme | 2 | 1.000 | 4.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+| verbal_root_alternation | 1 | 1.000 | 3.000 | 1.000 | 1.000 | 1.000 | 0.000 |
+
+### phoneme_syllable_baseline
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 0.500 | 3.000 | 0.500 | 0.500 | 0.000 | 1.000 |
+| adverb_comparative | 2 | 0.250 | 2.500 | 0.250 | 0.250 | 0.000 | 1.000 |
+| indefinite_pronoun | 2 | 0.500 | 4.000 | 0.333 | 1.000 | 0.000 | 1.000 |
+| nominal_root_alternation | 3 | 0.000 | 1.333 | 0.000 | 0.000 | 0.000 | 1.000 |
+| prefixed_verb_theme | 2 | 0.667 | 4.000 | 0.333 | 0.333 | 0.000 | 1.000 |
+| verbal_root_alternation | 1 | 0.500 | 3.000 | 0.500 | 0.500 | 0.000 | 1.000 |
+
+### tiktoken_cl100k
+
+| category | cases | boundary F1 | fertility | align P | align R | exact roles | fallback |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| adjective_stem_extension | 2 | 0.583 | 2.500 | 0.750 | 0.500 | 0.000 | 0.000 |
+| adverb_comparative | 2 | 0.200 | 3.000 | 0.167 | 0.250 | 0.000 | 0.000 |
+| indefinite_pronoun | 2 | 0.000 | 6.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| nominal_root_alternation | 3 | 0.333 | 2.333 | 0.333 | 0.333 | 0.000 | 0.000 |
+| prefixed_verb_theme | 2 | 0.500 | 4.000 | 0.500 | 0.500 | 0.000 | 0.000 |
+| verbal_root_alternation | 1 | 0.333 | 5.000 | 0.250 | 0.500 | 0.000 | 0.000 |
+
+## Failures
+
+### polish_morph_current
+
+- `psem` (nominal_root_alternation, heuristic):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `pse|ROOT m|INST_LOC_SG_ADJ`
+- `psu` (nominal_root_alternation, heuristic):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `psu|ROOT`
+- `ręce` (nominal_root_alternation, heuristic):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `ręc|ROOT e|NOM_ACC_PL`
+
+### phoneme_syllable_baseline
+
+- `bardziej` (adverb_comparative, phoneme_syllable):
+  - gold: `bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `bar|PHON_FALLBACK dźej|PHON_FALLBACK`
+- `najbardziej` (adverb_comparative, phoneme_syllable):
+  - gold: `naj|PREFIX bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `naj|PHON_FALLBACK bar|PHON_FALLBACK dźej|PHON_FALLBACK`
+- `kogokolwiek` (indefinite_pronoun, phoneme_syllable):
+  - gold: `kogo|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `ko|PHON_FALLBACK go|PHON_FALLBACK kol|PHON_FALLBACK w'ek|PHON_FALLBACK`
+- `czegokolwiek` (indefinite_pronoun, phoneme_syllable):
+  - gold: `czego|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `cze|PHON_FALLBACK go|PHON_FALLBACK kol|PHON_FALLBACK w'ek|PHON_FALLBACK`
+- `przemierzają` (prefixed_verb_theme, phoneme_syllable):
+  - gold: `prze|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `psze|PHON_FALLBACK m'e|PHON_FALLBACK ża|PHON_FALLBACK ją|PHON_FALLBACK`
+- `odmierzają` (prefixed_verb_theme, phoneme_syllable):
+  - gold: `od|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `od|PHON_FALLBACK m'e|PHON_FALLBACK ża|PHON_FALLBACK ją|PHON_FALLBACK`
+- `innego` (adjective_stem_extension, phoneme_syllable):
+  - gold: `in|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `in|PHON_FALLBACK ne|PHON_FALLBACK go|PHON_FALLBACK`
+- `czynnego` (adjective_stem_extension, phoneme_syllable):
+  - gold: `czyn|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `czyn|PHON_FALLBACK ne|PHON_FALLBACK go|PHON_FALLBACK`
+- `psem` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `psem|PHON_FALLBACK`
+- `psu` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `psu|PHON_FALLBACK`
+- `ręce` (nominal_root_alternation, phoneme_syllable):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `rę|PHON_FALLBACK ce|PHON_FALLBACK`
+- `przyszliśmy` (verbal_root_alternation, phoneme_syllable):
+  - gold: `przy|PREFIX sz|ROOT_ALLOMORPH liśmy|PAST_1PL`
+  - pred: `pszy|PHON_FALLBACK szliś|PHON_FALLBACK my|PHON_FALLBACK`
+
+### tiktoken_cl100k
+
+- `bardziej` (adverb_comparative, tiktoken_cl100k):
+  - gold: `bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `bard|BPE ziej|BPE`
+- `najbardziej` (adverb_comparative, tiktoken_cl100k):
+  - gold: `naj|PREFIX bardz|ROOT_ALLOMORPH iej|ADV_COMPARATIVE`
+  - pred: `n|BPE aj|BPE bard|BPE ziej|BPE`
+- `kogokolwiek` (indefinite_pronoun, tiktoken_cl100k):
+  - gold: `kogo|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `k|BPE og|BPE ok|BPE ol|BPE w|BPE iek|BPE`
+- `czegokolwiek` (indefinite_pronoun, tiktoken_cl100k):
+  - gold: `czego|PRONOUN_BASE kolwiek|INDEF_PARTICLE`
+  - pred: `cz|BPE eg|BPE ok|BPE ol|BPE w|BPE iek|BPE`
+- `przemierzają` (prefixed_verb_theme, tiktoken_cl100k):
+  - gold: `prze|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `pr|BPE zem|BPE ierz|BPE ają|BPE`
+- `odmierzają` (prefixed_verb_theme, tiktoken_cl100k):
+  - gold: `od|PREFIX mierz|ROOT aj|VERB_THEME ą|PRES_3PL`
+  - pred: `od|BPE m|BPE ierz|BPE ają|BPE`
+- `innego` (adjective_stem_extension, tiktoken_cl100k):
+  - gold: `in|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `inn|BPE ego|BPE`
+- `czynnego` (adjective_stem_extension, tiktoken_cl100k):
+  - gold: `czyn|ROOT n|STEM_EXT ego|GEN_SG_MN_ADJ`
+  - pred: `cz|BPE yn|BPE nego|BPE`
+- `psem` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ps|ROOT_ALLOMORPH em|INST_SG`
+  - pred: `p|BPE sem|BPE`
+- `psu` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ps|ROOT_ALLOMORPH u|GEN_LOC_SG`
+  - pred: `ps|BPE u|BPE`
+- `ręce` (nominal_root_alternation, tiktoken_cl100k):
+  - gold: `ręc|ROOT_ALLOMORPH e|NOM_ACC_PL`
+  - pred: `r|BPE ę|BPE ce|BPE`
+- `przyszliśmy` (verbal_root_alternation, tiktoken_cl100k):
+  - gold: `przy|PREFIX sz|ROOT_ALLOMORPH liśmy|PAST_1PL`
+  - pred: `pr|BPE z|BPE ysz|BPE li|BPE śmy|BPE`

--- a/public/data/chomsky-sota2026/reports/morph_benchmark_results.json
+++ b/public/data/chomsky-sota2026/reports/morph_benchmark_results.json
@@ -1,0 +1,2027 @@
+{
+  "benchmark": {
+    "name": "Polish Morphological Boundary Benchmark",
+    "version": "0.1.0",
+    "description": "Small gold set for Polish morpheme boundary evaluation. Cases are grouped by failure mode rather than by frequency.",
+    "cases": [
+      {
+        "id": "adv_comp_bardziej",
+        "category": "adverb_comparative",
+        "surface": "bardziej",
+        "expected_morph_tags": [
+          "adv:com"
+        ],
+        "gold": [
+          [
+            "bardz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "iej",
+            "ADV_COMPARATIVE"
+          ]
+        ]
+      },
+      {
+        "id": "adv_comp_najbardziej",
+        "category": "adverb_comparative",
+        "surface": "najbardziej",
+        "expected_morph_tags": [
+          "adv:sup"
+        ],
+        "gold": [
+          [
+            "naj",
+            "PREFIX"
+          ],
+          [
+            "bardz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "iej",
+            "ADV_COMPARATIVE"
+          ]
+        ]
+      },
+      {
+        "id": "pron_kolwiek_kogo",
+        "category": "indefinite_pronoun",
+        "surface": "kogokolwiek",
+        "expected_morph_tags": [
+          "subst:sg:gen",
+          "subst:sg:acc"
+        ],
+        "gold": [
+          [
+            "kogo",
+            "PRONOUN_BASE"
+          ],
+          [
+            "kolwiek",
+            "INDEF_PARTICLE"
+          ]
+        ]
+      },
+      {
+        "id": "pron_kolwiek_czego",
+        "category": "indefinite_pronoun",
+        "surface": "czegokolwiek",
+        "expected_morph_tags": [
+          "subst:sg:gen",
+          "subst:sg:acc"
+        ],
+        "gold": [
+          [
+            "czego",
+            "PRONOUN_BASE"
+          ],
+          [
+            "kolwiek",
+            "INDEF_PARTICLE"
+          ]
+        ]
+      },
+      {
+        "id": "verb_pref_przemierzaja",
+        "category": "prefixed_verb_theme",
+        "surface": "przemierzają",
+        "expected_morph_tags": [
+          "fin:pl:ter"
+        ],
+        "gold": [
+          [
+            "prze",
+            "PREFIX"
+          ],
+          [
+            "mierz",
+            "ROOT"
+          ],
+          [
+            "aj",
+            "VERB_THEME"
+          ],
+          [
+            "ą",
+            "PRES_3PL"
+          ]
+        ]
+      },
+      {
+        "id": "verb_pref_odmierzaja",
+        "category": "prefixed_verb_theme",
+        "surface": "odmierzają",
+        "expected_morph_tags": [
+          "fin:pl:ter"
+        ],
+        "gold": [
+          [
+            "od",
+            "PREFIX"
+          ],
+          [
+            "mierz",
+            "ROOT"
+          ],
+          [
+            "aj",
+            "VERB_THEME"
+          ],
+          [
+            "ą",
+            "PRES_3PL"
+          ]
+        ]
+      },
+      {
+        "id": "adj_stem_ext_innego",
+        "category": "adjective_stem_extension",
+        "surface": "innego",
+        "expected_morph_tags": [
+          "adj:sg:gen",
+          "adj:sg:acc"
+        ],
+        "gold": [
+          [
+            "in",
+            "ROOT"
+          ],
+          [
+            "n",
+            "STEM_EXT"
+          ],
+          [
+            "ego",
+            "GEN_SG_MN_ADJ"
+          ]
+        ]
+      },
+      {
+        "id": "adj_stem_ext_czynnego",
+        "category": "adjective_stem_extension",
+        "surface": "czynnego",
+        "expected_morph_tags": [
+          "adj:sg:gen",
+          "adj:sg:acc"
+        ],
+        "gold": [
+          [
+            "czyn",
+            "ROOT"
+          ],
+          [
+            "n",
+            "STEM_EXT"
+          ],
+          [
+            "ego",
+            "GEN_SG_MN_ADJ"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_psem",
+        "category": "nominal_root_alternation",
+        "surface": "psem",
+        "expected_morph_tags": [
+          "subst:sg:inst"
+        ],
+        "gold": [
+          [
+            "ps",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "em",
+            "INST_SG"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_psu",
+        "category": "nominal_root_alternation",
+        "surface": "psu",
+        "expected_morph_tags": [
+          "subst:sg:dat"
+        ],
+        "gold": [
+          [
+            "ps",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "u",
+            "GEN_LOC_SG"
+          ]
+        ]
+      },
+      {
+        "id": "noun_alt_rece",
+        "category": "nominal_root_alternation",
+        "surface": "ręce",
+        "expected_morph_tags": [
+          "subst:sg:dat",
+          "subst:sg:loc",
+          "subst:pl:nom",
+          "subst:pl:acc"
+        ],
+        "gold": [
+          [
+            "ręc",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "e",
+            "NOM_ACC_PL"
+          ]
+        ]
+      },
+      {
+        "id": "verb_allomorph_przyszlismy",
+        "category": "verbal_root_alternation",
+        "surface": "przyszliśmy",
+        "expected_morph_tags": [
+          "praet:pl"
+        ],
+        "gold": [
+          [
+            "przy",
+            "PREFIX"
+          ],
+          [
+            "sz",
+            "ROOT_ALLOMORPH"
+          ],
+          [
+            "liśmy",
+            "PAST_1PL"
+          ]
+        ]
+      }
+    ]
+  },
+  "analyzers": [
+    {
+      "name": "morfeusz2",
+      "status": "available",
+      "recognized_rate": 1.0,
+      "expected_tag_rate": 1.0,
+      "note": "form analyzer baseline; does not provide morpheme boundaries"
+    },
+    {
+      "name": "concraft-pl",
+      "status": "missing",
+      "recognized_rate": 0.0,
+      "expected_tag_rate": 0.0,
+      "note": "not installed in this environment"
+    }
+  ],
+  "results": [
+    {
+      "system": "polish_morph_current",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.8333333333333334,
+        "fertility": 2.5833333333333335,
+        "morph_alignment_precision": 0.8333333333333334,
+        "morph_alignment_recall": 0.8333333333333334,
+        "segment_exact": 0.8333333333333334,
+        "role_exact": 0.75,
+        "fallback_rate": 0.0,
+        "sources": {
+          "rule:adverb_comparative": 2,
+          "rule:indefinite_pronoun": 2,
+          "rule:present_3pl_aja": 2,
+          "rule:adjective_stem_extension": 2,
+          "heuristic": 3,
+          "ladder_entry": 1
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 3.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.5,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 1.6666666666666667,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.3333333333333333,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 4.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 1.0,
+          "fertility": 3.0,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 1.0,
+          "role_exact": 1.0,
+          "fallback_rate": 0.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "source": "rule:adverb_comparative",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "source": "rule:adverb_comparative",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "source": "rule:indefinite_pronoun",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "source": "rule:indefinite_pronoun",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "source": "rule:present_3pl_aja",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "source": "rule:present_3pl_aja",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "source": "rule:adjective_stem_extension",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "source": "rule:adjective_stem_extension",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "pse",
+              "ROOT"
+            ],
+            [
+              "m",
+              "INST_LOC_SG_ADJ"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psu",
+              "ROOT"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "ręc",
+              "ROOT"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "source": "heuristic",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "source": "ladder_entry",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": true
+        }
+      ]
+    },
+    {
+      "system": "phoneme_syllable_baseline",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.3611111111111111,
+        "fertility": 2.8333333333333335,
+        "morph_alignment_precision": 0.27777777777777773,
+        "morph_alignment_recall": 0.3888888888888889,
+        "segment_exact": 0.0,
+        "role_exact": 0.0,
+        "fallback_rate": 1.0,
+        "sources": {
+          "phoneme_syllable": 12
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.25,
+          "fertility": 2.5,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.25,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.0,
+          "fertility": 1.3333333333333333,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 1.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bar",
+              "PHON_FALLBACK"
+            ],
+            [
+              "dźej",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "naj",
+              "PHON_FALLBACK"
+            ],
+            [
+              "bar",
+              "PHON_FALLBACK"
+            ],
+            [
+              "dźej",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "ko",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ],
+            [
+              "kol",
+              "PHON_FALLBACK"
+            ],
+            [
+              "w'ek",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "cze",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ],
+            [
+              "kol",
+              "PHON_FALLBACK"
+            ],
+            [
+              "w'ek",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "psze",
+              "PHON_FALLBACK"
+            ],
+            [
+              "m'e",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ża",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ją",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "PHON_FALLBACK"
+            ],
+            [
+              "m'e",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ża",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ją",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "in",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ne",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "czyn",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ne",
+              "PHON_FALLBACK"
+            ],
+            [
+              "go",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psem",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "psu",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "rę",
+              "PHON_FALLBACK"
+            ],
+            [
+              "ce",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pszy",
+              "PHON_FALLBACK"
+            ],
+            [
+              "szliś",
+              "PHON_FALLBACK"
+            ],
+            [
+              "my",
+              "PHON_FALLBACK"
+            ]
+          ],
+          "source": "phoneme_syllable",
+          "fallback": true,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        }
+      ]
+    },
+    {
+      "system": "tiktoken_cl100k",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.325,
+        "fertility": 3.5833333333333335,
+        "morph_alignment_precision": 0.34027777777777773,
+        "morph_alignment_recall": 0.3333333333333333,
+        "segment_exact": 0.08333333333333333,
+        "role_exact": 0.0,
+        "fallback_rate": 0.0,
+        "sources": {
+          "tiktoken_cl100k": 12
+        }
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.5833333333333333,
+          "fertility": 2.5,
+          "morph_alignment_precision": 0.75,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.2,
+          "fertility": 3.0,
+          "morph_alignment_precision": 0.16666666666666666,
+          "morph_alignment_recall": 0.25,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.0,
+          "fertility": 6.0,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 2.3333333333333335,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": 0.3333333333333333,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 4.0,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 5.0,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": 0.0,
+          "role_exact": 0.0,
+          "fallback_rate": 0.0
+        }
+      },
+      "rows": [
+        {
+          "id": "adv_comp_bardziej",
+          "category": "adverb_comparative",
+          "surface": "bardziej",
+          "gold": [
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "bard",
+              "BPE"
+            ],
+            [
+              "ziej",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adv_comp_najbardziej",
+          "category": "adverb_comparative",
+          "surface": "najbardziej",
+          "gold": [
+            [
+              "naj",
+              "PREFIX"
+            ],
+            [
+              "bardz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "iej",
+              "ADV_COMPARATIVE"
+            ]
+          ],
+          "predicted": [
+            [
+              "n",
+              "BPE"
+            ],
+            [
+              "aj",
+              "BPE"
+            ],
+            [
+              "bard",
+              "BPE"
+            ],
+            [
+              "ziej",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.4,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_kogo",
+          "category": "indefinite_pronoun",
+          "surface": "kogokolwiek",
+          "gold": [
+            [
+              "kogo",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "k",
+              "BPE"
+            ],
+            [
+              "og",
+              "BPE"
+            ],
+            [
+              "ok",
+              "BPE"
+            ],
+            [
+              "ol",
+              "BPE"
+            ],
+            [
+              "w",
+              "BPE"
+            ],
+            [
+              "iek",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 6,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "pron_kolwiek_czego",
+          "category": "indefinite_pronoun",
+          "surface": "czegokolwiek",
+          "gold": [
+            [
+              "czego",
+              "PRONOUN_BASE"
+            ],
+            [
+              "kolwiek",
+              "INDEF_PARTICLE"
+            ]
+          ],
+          "predicted": [
+            [
+              "cz",
+              "BPE"
+            ],
+            [
+              "eg",
+              "BPE"
+            ],
+            [
+              "ok",
+              "BPE"
+            ],
+            [
+              "ol",
+              "BPE"
+            ],
+            [
+              "w",
+              "BPE"
+            ],
+            [
+              "iek",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 6,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_przemierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "przemierzają",
+          "gold": [
+            [
+              "prze",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pr",
+              "BPE"
+            ],
+            [
+              "zem",
+              "BPE"
+            ],
+            [
+              "ierz",
+              "BPE"
+            ],
+            [
+              "ają",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 4,
+          "morph_alignment_precision": 0.3333333333333333,
+          "morph_alignment_recall": 0.3333333333333333,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_pref_odmierzaja",
+          "category": "prefixed_verb_theme",
+          "surface": "odmierzają",
+          "gold": [
+            [
+              "od",
+              "PREFIX"
+            ],
+            [
+              "mierz",
+              "ROOT"
+            ],
+            [
+              "aj",
+              "VERB_THEME"
+            ],
+            [
+              "ą",
+              "PRES_3PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "od",
+              "BPE"
+            ],
+            [
+              "m",
+              "BPE"
+            ],
+            [
+              "ierz",
+              "BPE"
+            ],
+            [
+              "ają",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 0.6666666666666666,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 4,
+          "morph_alignment_precision": 0.6666666666666666,
+          "morph_alignment_recall": 0.6666666666666666,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_innego",
+          "category": "adjective_stem_extension",
+          "surface": "innego",
+          "gold": [
+            [
+              "in",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "inn",
+              "BPE"
+            ],
+            [
+              "ego",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "adj_stem_ext_czynnego",
+          "category": "adjective_stem_extension",
+          "surface": "czynnego",
+          "gold": [
+            [
+              "czyn",
+              "ROOT"
+            ],
+            [
+              "n",
+              "STEM_EXT"
+            ],
+            [
+              "ego",
+              "GEN_SG_MN_ADJ"
+            ]
+          ],
+          "predicted": [
+            [
+              "cz",
+              "BPE"
+            ],
+            [
+              "yn",
+              "BPE"
+            ],
+            [
+              "nego",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.5,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.5,
+          "fertility": 3,
+          "morph_alignment_precision": 0.5,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psem",
+          "category": "nominal_root_alternation",
+          "surface": "psem",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "em",
+              "INST_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "p",
+              "BPE"
+            ],
+            [
+              "sem",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_psu",
+          "category": "nominal_root_alternation",
+          "surface": "psu",
+          "gold": [
+            [
+              "ps",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "u",
+              "GEN_LOC_SG"
+            ]
+          ],
+          "predicted": [
+            [
+              "ps",
+              "BPE"
+            ],
+            [
+              "u",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "morph_alignment_precision": 1.0,
+          "morph_alignment_recall": 1.0,
+          "segment_exact": true,
+          "role_exact": false
+        },
+        {
+          "id": "noun_alt_rece",
+          "category": "nominal_root_alternation",
+          "surface": "ręce",
+          "gold": [
+            [
+              "ręc",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "e",
+              "NOM_ACC_PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "r",
+              "BPE"
+            ],
+            [
+              "ę",
+              "BPE"
+            ],
+            [
+              "ce",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 3,
+          "morph_alignment_precision": 0.0,
+          "morph_alignment_recall": 0.0,
+          "segment_exact": false,
+          "role_exact": false
+        },
+        {
+          "id": "verb_allomorph_przyszlismy",
+          "category": "verbal_root_alternation",
+          "surface": "przyszliśmy",
+          "gold": [
+            [
+              "przy",
+              "PREFIX"
+            ],
+            [
+              "sz",
+              "ROOT_ALLOMORPH"
+            ],
+            [
+              "liśmy",
+              "PAST_1PL"
+            ]
+          ],
+          "predicted": [
+            [
+              "pr",
+              "BPE"
+            ],
+            [
+              "z",
+              "BPE"
+            ],
+            [
+              "ysz",
+              "BPE"
+            ],
+            [
+              "li",
+              "BPE"
+            ],
+            [
+              "śmy",
+              "BPE"
+            ]
+          ],
+          "source": "tiktoken_cl100k",
+          "fallback": false,
+          "boundary_precision": 0.25,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.3333333333333333,
+          "fertility": 5,
+          "morph_alignment_precision": 0.25,
+          "morph_alignment_recall": 0.5,
+          "segment_exact": false,
+          "role_exact": false
+        }
+      ]
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/reports/morph_bpe_report.md
+++ b/public/data/chomsky-sota2026/reports/morph_bpe_report.md
@@ -1,0 +1,28 @@
+# MorphBPE/SKMT-Style Tokenizer Smoke
+
+This is a constrained-BPE pipeline check on the current tiny Polish gold set, not a final tokenizer result.
+
+| system | cases | boundary F1 | fertility | align P | align R |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| standard_bpe_smoke | 12 | 0.510 | 3.000 | 0.544 | 0.597 |
+| morph_bpe_constrained_smoke | 12 | 0.925 | 3.167 | 0.889 | 1.000 |
+
+## Failures
+
+### standard_bpe_smoke
+
+- `bardziej` gold=`bardz @@ iej` pred=`b @@ a @@ r @@ dziej`
+- `najbardziej` gold=`naj @@ bardz @@ iej` pred=`n @@ aj @@ b @@ a @@ r @@ dziej`
+- `kogokolwiek` gold=`kogo @@ kolwiek` pred=`ko @@ go @@ kolwiek`
+- `czegokolwiek` gold=`czego @@ kolwiek` pred=`cz @@ ego @@ kolwiek`
+- `przemierzają` gold=`prze @@ mierz @@ aj @@ ą` pred=`prze @@ mierzają`
+- `odmierzają` gold=`od @@ mierz @@ aj @@ ą` pred=`od @@ mierzają`
+- `innego` gold=`in @@ n @@ ego` pred=`innego`
+- `czynnego` gold=`czyn @@ n @@ ego` pred=`czy @@ nnego`
+- `przyszliśmy` gold=`przy @@ sz @@ liśmy` pred=`prz @@ y @@ sz @@ li @@ ś @@ m @@ y`
+
+### morph_bpe_constrained_smoke
+
+- `najbardziej` gold=`naj @@ bardz @@ iej` pred=`n @@ aj @@ bardz @@ iej`
+- `czynnego` gold=`czyn @@ n @@ ego` pred=`czy @@ n @@ n @@ ego`
+- `przyszliśmy` gold=`przy @@ sz @@ liśmy` pred=`prz @@ y @@ sz @@ li @@ ś @@ m @@ y`

--- a/public/data/chomsky-sota2026/reports/morph_bpe_results.json
+++ b/public/data/chomsky-sota2026/reports/morph_bpe_results.json
@@ -1,0 +1,1114 @@
+{
+  "warning": "Smoke run on current gold set. Full MorphBPE/SKMT needs corpus-scale training and downstream LLM evaluation.",
+  "train_paths": [
+    "data/morph_benchmark.json",
+    "data/synthetic_morph_examples.json"
+  ],
+  "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+  "merges": {
+    "standard_bpe": [
+      [
+        "a",
+        "j"
+      ],
+      [
+        "aj",
+        "ą"
+      ],
+      [
+        "i",
+        "e"
+      ],
+      [
+        "c",
+        "z"
+      ],
+      [
+        "g",
+        "o"
+      ],
+      [
+        "r",
+        "z"
+      ],
+      [
+        "k",
+        "o"
+      ],
+      [
+        "e",
+        "go"
+      ],
+      [
+        "o",
+        "d"
+      ],
+      [
+        "d",
+        "z"
+      ],
+      [
+        "ie",
+        "j"
+      ],
+      [
+        "n",
+        "ego"
+      ],
+      [
+        "ko",
+        "l"
+      ],
+      [
+        "s",
+        "z"
+      ],
+      [
+        "kol",
+        "w"
+      ],
+      [
+        "kolw",
+        "ie"
+      ],
+      [
+        "kolwie",
+        "k"
+      ],
+      [
+        "r",
+        "o"
+      ],
+      [
+        "p",
+        "rz"
+      ],
+      [
+        "n",
+        "nego"
+      ],
+      [
+        "cz",
+        "y"
+      ],
+      [
+        "prz",
+        "e"
+      ],
+      [
+        "sz",
+        "u"
+      ],
+      [
+        "szu",
+        "k"
+      ],
+      [
+        "szuk",
+        "ają"
+      ],
+      [
+        "b",
+        "ie"
+      ],
+      [
+        "bie",
+        "r"
+      ],
+      [
+        "w",
+        "o"
+      ],
+      [
+        "n",
+        "a"
+      ],
+      [
+        "na",
+        "d"
+      ],
+      [
+        "s",
+        "ają"
+      ],
+      [
+        "e",
+        "m"
+      ],
+      [
+        "l",
+        "i"
+      ],
+      [
+        "wo",
+        "ł"
+      ],
+      [
+        "woł",
+        "ają"
+      ],
+      [
+        "bier",
+        "ają"
+      ],
+      [
+        "m",
+        "ie"
+      ],
+      [
+        "mie",
+        "rz"
+      ],
+      [
+        "mierz",
+        "ają"
+      ],
+      [
+        "p",
+        "o"
+      ],
+      [
+        "z",
+        "a"
+      ],
+      [
+        "czy",
+        "t"
+      ],
+      [
+        "czyt",
+        "ają"
+      ],
+      [
+        "i",
+        "nnego"
+      ],
+      [
+        "p",
+        "s"
+      ],
+      [
+        "dz",
+        "ie"
+      ],
+      [
+        "li",
+        "cz"
+      ],
+      [
+        "licz",
+        "ają"
+      ],
+      [
+        "ro",
+        "z"
+      ],
+      [
+        "a",
+        "w"
+      ],
+      [
+        "p",
+        "i"
+      ],
+      [
+        "pi",
+        "sają"
+      ],
+      [
+        "w",
+        "y"
+      ],
+      [
+        "k",
+        "ro"
+      ],
+      [
+        "kro",
+        "j"
+      ],
+      [
+        "kroj",
+        "ają"
+      ],
+      [
+        "d",
+        "o"
+      ],
+      [
+        "p",
+        "od"
+      ],
+      [
+        "dz",
+        "iej"
+      ],
+      [
+        "r",
+        "ę"
+      ],
+      [
+        "rę",
+        "c"
+      ],
+      [
+        "s",
+        "t"
+      ],
+      [
+        "st",
+        "aw"
+      ],
+      [
+        "staw",
+        "ają"
+      ]
+    ],
+    "morph_bpe": [
+      [
+        "a",
+        "j"
+      ],
+      [
+        "i",
+        "e"
+      ],
+      [
+        "c",
+        "z"
+      ],
+      [
+        "g",
+        "o"
+      ],
+      [
+        "r",
+        "z"
+      ],
+      [
+        "k",
+        "o"
+      ],
+      [
+        "e",
+        "go"
+      ],
+      [
+        "o",
+        "d"
+      ],
+      [
+        "d",
+        "z"
+      ],
+      [
+        "ie",
+        "j"
+      ],
+      [
+        "ko",
+        "l"
+      ],
+      [
+        "s",
+        "z"
+      ],
+      [
+        "kol",
+        "w"
+      ],
+      [
+        "kolw",
+        "ie"
+      ],
+      [
+        "kolwie",
+        "k"
+      ],
+      [
+        "r",
+        "o"
+      ],
+      [
+        "p",
+        "rz"
+      ],
+      [
+        "cz",
+        "y"
+      ],
+      [
+        "prz",
+        "e"
+      ],
+      [
+        "sz",
+        "u"
+      ],
+      [
+        "szu",
+        "k"
+      ],
+      [
+        "b",
+        "ie"
+      ],
+      [
+        "bie",
+        "r"
+      ],
+      [
+        "w",
+        "o"
+      ],
+      [
+        "n",
+        "a"
+      ],
+      [
+        "na",
+        "d"
+      ],
+      [
+        "e",
+        "m"
+      ],
+      [
+        "l",
+        "i"
+      ],
+      [
+        "wo",
+        "ł"
+      ],
+      [
+        "m",
+        "ie"
+      ],
+      [
+        "mie",
+        "rz"
+      ],
+      [
+        "p",
+        "o"
+      ],
+      [
+        "z",
+        "a"
+      ],
+      [
+        "czy",
+        "t"
+      ],
+      [
+        "i",
+        "n"
+      ],
+      [
+        "p",
+        "s"
+      ],
+      [
+        "dz",
+        "ie"
+      ],
+      [
+        "li",
+        "cz"
+      ],
+      [
+        "ro",
+        "z"
+      ],
+      [
+        "a",
+        "w"
+      ],
+      [
+        "p",
+        "i"
+      ],
+      [
+        "pi",
+        "s"
+      ],
+      [
+        "w",
+        "y"
+      ],
+      [
+        "k",
+        "ro"
+      ],
+      [
+        "kro",
+        "j"
+      ],
+      [
+        "d",
+        "o"
+      ],
+      [
+        "p",
+        "od"
+      ],
+      [
+        "r",
+        "ę"
+      ],
+      [
+        "rę",
+        "c"
+      ],
+      [
+        "s",
+        "t"
+      ],
+      [
+        "st",
+        "aw"
+      ],
+      [
+        "b",
+        "a"
+      ],
+      [
+        "ba",
+        "r"
+      ],
+      [
+        "bar",
+        "dz"
+      ],
+      [
+        "o",
+        "cz"
+      ],
+      [
+        "dzie",
+        "c"
+      ],
+      [
+        "l",
+        "u"
+      ],
+      [
+        "lu",
+        "dz"
+      ],
+      [
+        "n",
+        "ó"
+      ],
+      [
+        "nó",
+        "ż"
+      ],
+      [
+        "n",
+        "o"
+      ],
+      [
+        "no",
+        "s"
+      ],
+      [
+        "ko",
+        "go"
+      ],
+      [
+        "cz",
+        "ego"
+      ]
+    ]
+  },
+  "results": [
+    {
+      "system": "standard_bpe_smoke",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.5099206349206349,
+        "fertility": 3.0,
+        "alignment_precision": 0.5444444444444444,
+        "alignment_recall": 0.5972222222222222
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.0,
+          "fertility": 1.5,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.14285714285714288,
+          "fertility": 5.0,
+          "alignment_precision": 0.1,
+          "alignment_recall": 0.25
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3.0,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 0.5,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 7.0,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      },
+      "rows": [
+        {
+          "surface": "bardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "b",
+            "a",
+            "r",
+            "dziej"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 4,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "najbardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "naj",
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "n",
+            "aj",
+            "b",
+            "a",
+            "r",
+            "dziej"
+          ],
+          "boundary_precision": 0.2,
+          "boundary_recall": 0.5,
+          "boundary_f1": 0.28571428571428575,
+          "fertility": 6,
+          "alignment_precision": 0.2,
+          "alignment_recall": 0.5
+        },
+        {
+          "surface": "kogokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "kogo",
+            "kolwiek"
+          ],
+          "predicted": [
+            "ko",
+            "go",
+            "kolwiek"
+          ],
+          "boundary_precision": 0.5,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czegokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "czego",
+            "kolwiek"
+          ],
+          "predicted": [
+            "cz",
+            "ego",
+            "kolwiek"
+          ],
+          "boundary_precision": 0.5,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.6666666666666666,
+          "fertility": 3,
+          "alignment_precision": 0.5,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przemierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "prze",
+            "mierzają"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.5,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        {
+          "surface": "odmierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "od",
+            "mierzają"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 0.3333333333333333,
+          "boundary_f1": 0.5,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 0.3333333333333333
+        },
+        {
+          "surface": "innego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "innego"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 1,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "czynnego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "czyn",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "czy",
+            "nnego"
+          ],
+          "boundary_precision": 0.0,
+          "boundary_recall": 0.0,
+          "boundary_f1": 0.0,
+          "fertility": 2,
+          "alignment_precision": 0.0,
+          "alignment_recall": 0.0
+        },
+        {
+          "surface": "psem",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "em"
+          ],
+          "predicted": [
+            "ps",
+            "em"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psu",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "u"
+          ],
+          "predicted": [
+            "ps",
+            "u"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "ręce",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ręc",
+            "e"
+          ],
+          "predicted": [
+            "ręc",
+            "e"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przyszliśmy",
+          "category": "verbal_root_alternation",
+          "gold": [
+            "przy",
+            "sz",
+            "liśmy"
+          ],
+          "predicted": [
+            "prz",
+            "y",
+            "sz",
+            "li",
+            "ś",
+            "m",
+            "y"
+          ],
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 7,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      ]
+    },
+    {
+      "system": "morph_bpe_constrained_smoke",
+      "summary": {
+        "cases": 12,
+        "boundary_f1": 0.9249999999999999,
+        "fertility": 3.1666666666666665,
+        "alignment_precision": 0.8888888888888888,
+        "alignment_recall": 1.0
+      },
+      "categories": {
+        "adjective_stem_extension": {
+          "cases": 2,
+          "boundary_f1": 0.9,
+          "fertility": 3.5,
+          "alignment_precision": 0.8333333333333333,
+          "alignment_recall": 1.0
+        },
+        "adverb_comparative": {
+          "cases": 2,
+          "boundary_f1": 0.9,
+          "fertility": 3.0,
+          "alignment_precision": 0.8333333333333333,
+          "alignment_recall": 1.0
+        },
+        "indefinite_pronoun": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "nominal_root_alternation": {
+          "cases": 3,
+          "boundary_f1": 1.0,
+          "fertility": 2.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "prefixed_verb_theme": {
+          "cases": 2,
+          "boundary_f1": 1.0,
+          "fertility": 4.0,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        "verbal_root_alternation": {
+          "cases": 1,
+          "boundary_f1": 0.5,
+          "fertility": 7.0,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      },
+      "rows": [
+        {
+          "surface": "bardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "bardz",
+            "iej"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "najbardziej",
+          "category": "adverb_comparative",
+          "gold": [
+            "naj",
+            "bardz",
+            "iej"
+          ],
+          "predicted": [
+            "n",
+            "aj",
+            "bardz",
+            "iej"
+          ],
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.8,
+          "fertility": 4,
+          "alignment_precision": 0.6666666666666666,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "kogokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "kogo",
+            "kolwiek"
+          ],
+          "predicted": [
+            "kogo",
+            "kolwiek"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czegokolwiek",
+          "category": "indefinite_pronoun",
+          "gold": [
+            "czego",
+            "kolwiek"
+          ],
+          "predicted": [
+            "czego",
+            "kolwiek"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przemierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "prze",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "odmierzają",
+          "category": "prefixed_verb_theme",
+          "gold": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "predicted": [
+            "od",
+            "mierz",
+            "aj",
+            "ą"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 4,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "innego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "in",
+            "n",
+            "ego"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 3,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "czynnego",
+          "category": "adjective_stem_extension",
+          "gold": [
+            "czyn",
+            "n",
+            "ego"
+          ],
+          "predicted": [
+            "czy",
+            "n",
+            "n",
+            "ego"
+          ],
+          "boundary_precision": 0.6666666666666666,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.8,
+          "fertility": 4,
+          "alignment_precision": 0.6666666666666666,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psem",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "em"
+          ],
+          "predicted": [
+            "ps",
+            "em"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "psu",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ps",
+            "u"
+          ],
+          "predicted": [
+            "ps",
+            "u"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "ręce",
+          "category": "nominal_root_alternation",
+          "gold": [
+            "ręc",
+            "e"
+          ],
+          "predicted": [
+            "ręc",
+            "e"
+          ],
+          "boundary_precision": 1.0,
+          "boundary_recall": 1.0,
+          "boundary_f1": 1.0,
+          "fertility": 2,
+          "alignment_precision": 1.0,
+          "alignment_recall": 1.0
+        },
+        {
+          "surface": "przyszliśmy",
+          "category": "verbal_root_alternation",
+          "gold": [
+            "przy",
+            "sz",
+            "liśmy"
+          ],
+          "predicted": [
+            "prz",
+            "y",
+            "sz",
+            "li",
+            "ś",
+            "m",
+            "y"
+          ],
+          "boundary_precision": 0.3333333333333333,
+          "boundary_recall": 1.0,
+          "boundary_f1": 0.5,
+          "fertility": 7,
+          "alignment_precision": 0.3333333333333333,
+          "alignment_recall": 1.0
+        }
+      ]
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/reports/neural_segmenter_results.json
+++ b/public/data/chomsky-sota2026/reports/neural_segmenter_results.json
@@ -1,0 +1,212 @@
+{
+  "summary": {
+    "system": "neural_char_boundary_tagger_smoke",
+    "train_paths": [
+      "data/morph_benchmark.json",
+      "data/synthetic_morph_examples.json"
+    ],
+    "eval_path": "/Users/kacper/Local/Ventures/Slayer/bench/chomsky_sota2026/data/morph_benchmark.json",
+    "train_cases": 112,
+    "cases": 12,
+    "boundary_f1": 1.0,
+    "warning": "Smoke run on the tiny current gold set. This is pipeline validation, not a SOTA result."
+  },
+  "rows": [
+    {
+      "surface": "bardziej",
+      "category": "adverb_comparative",
+      "gold": [
+        "bardz",
+        "iej"
+      ],
+      "predicted": [
+        "bardz",
+        "iej"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "najbardziej",
+      "category": "adverb_comparative",
+      "gold": [
+        "naj",
+        "bardz",
+        "iej"
+      ],
+      "predicted": [
+        "naj",
+        "bardz",
+        "iej"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "kogokolwiek",
+      "category": "indefinite_pronoun",
+      "gold": [
+        "kogo",
+        "kolwiek"
+      ],
+      "predicted": [
+        "kogo",
+        "kolwiek"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "czegokolwiek",
+      "category": "indefinite_pronoun",
+      "gold": [
+        "czego",
+        "kolwiek"
+      ],
+      "predicted": [
+        "czego",
+        "kolwiek"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "przemierzają",
+      "category": "prefixed_verb_theme",
+      "gold": [
+        "prze",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "predicted": [
+        "prze",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "odmierzają",
+      "category": "prefixed_verb_theme",
+      "gold": [
+        "od",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "predicted": [
+        "od",
+        "mierz",
+        "aj",
+        "ą"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "innego",
+      "category": "adjective_stem_extension",
+      "gold": [
+        "in",
+        "n",
+        "ego"
+      ],
+      "predicted": [
+        "in",
+        "n",
+        "ego"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "czynnego",
+      "category": "adjective_stem_extension",
+      "gold": [
+        "czyn",
+        "n",
+        "ego"
+      ],
+      "predicted": [
+        "czyn",
+        "n",
+        "ego"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "psem",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ps",
+        "em"
+      ],
+      "predicted": [
+        "ps",
+        "em"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "psu",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ps",
+        "u"
+      ],
+      "predicted": [
+        "ps",
+        "u"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "ręce",
+      "category": "nominal_root_alternation",
+      "gold": [
+        "ręc",
+        "e"
+      ],
+      "predicted": [
+        "ręc",
+        "e"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    },
+    {
+      "surface": "przyszliśmy",
+      "category": "verbal_root_alternation",
+      "gold": [
+        "przy",
+        "sz",
+        "liśmy"
+      ],
+      "predicted": [
+        "przy",
+        "sz",
+        "liśmy"
+      ],
+      "boundary_precision": 1.0,
+      "boundary_recall": 1.0,
+      "boundary_f1": 1.0
+    }
+  ]
+}

--- a/public/data/chomsky-sota2026/reports/sigmorphon_export/metadata.tsv
+++ b/public/data/chomsky-sota2026/reports/sigmorphon_export/metadata.tsv
@@ -1,0 +1,13 @@
+id	surface	category	split	lemma	expected_morph_tags
+adv_comp_bardziej	bardziej	adverb_comparative	dev		adv:com
+adv_comp_najbardziej	najbardziej	adverb_comparative	dev		adv:sup
+pron_kolwiek_kogo	kogokolwiek	indefinite_pronoun	dev		subst:sg:gen,subst:sg:acc
+pron_kolwiek_czego	czegokolwiek	indefinite_pronoun	dev		subst:sg:gen,subst:sg:acc
+verb_pref_przemierzaja	przemierzają	prefixed_verb_theme	dev		fin:pl:ter
+verb_pref_odmierzaja	odmierzają	prefixed_verb_theme	dev		fin:pl:ter
+adj_stem_ext_innego	innego	adjective_stem_extension	dev		adj:sg:gen,adj:sg:acc
+adj_stem_ext_czynnego	czynnego	adjective_stem_extension	dev		adj:sg:gen,adj:sg:acc
+noun_alt_psem	psem	nominal_root_alternation	dev		subst:sg:inst
+noun_alt_psu	psu	nominal_root_alternation	dev		subst:sg:dat
+noun_alt_rece	ręce	nominal_root_alternation	dev		subst:sg:dat,subst:sg:loc,subst:pl:nom,subst:pl:acc
+verb_allomorph_przyszlismy	przyszliśmy	verbal_root_alternation	dev		praet:pl

--- a/public/data/chomsky-sota2026/reports/sigmorphon_export/word_level_gold.tsv
+++ b/public/data/chomsky-sota2026/reports/sigmorphon_export/word_level_gold.tsv
@@ -1,0 +1,12 @@
+bardziej	bardz @@ iej
+najbardziej	naj @@ bardz @@ iej
+kogokolwiek	kogo @@ kolwiek
+czegokolwiek	czego @@ kolwiek
+przemierzają	prze @@ mierz @@ aj @@ ą
+odmierzają	od @@ mierz @@ aj @@ ą
+innego	in @@ n @@ ego
+czynnego	czyn @@ n @@ ego
+psem	ps @@ em
+psu	ps @@ u
+ręce	ręc @@ e
+przyszliśmy	przy @@ sz @@ liśmy

--- a/public/data/chomsky-sota2026/reports/sigmorphon_export/word_level_gold_with_roles.tsv
+++ b/public/data/chomsky-sota2026/reports/sigmorphon_export/word_level_gold_with_roles.tsv
@@ -1,0 +1,12 @@
+bardziej	bardz|ROOT_ALLOMORPH @@ iej|ADV_COMPARATIVE
+najbardziej	naj|PREFIX @@ bardz|ROOT_ALLOMORPH @@ iej|ADV_COMPARATIVE
+kogokolwiek	kogo|PRONOUN_BASE @@ kolwiek|INDEF_PARTICLE
+czegokolwiek	czego|PRONOUN_BASE @@ kolwiek|INDEF_PARTICLE
+przemierzają	prze|PREFIX @@ mierz|ROOT @@ aj|VERB_THEME @@ ą|PRES_3PL
+odmierzają	od|PREFIX @@ mierz|ROOT @@ aj|VERB_THEME @@ ą|PRES_3PL
+innego	in|ROOT @@ n|STEM_EXT @@ ego|GEN_SG_MN_ADJ
+czynnego	czyn|ROOT @@ n|STEM_EXT @@ ego|GEN_SG_MN_ADJ
+psem	ps|ROOT_ALLOMORPH @@ em|INST_SG
+psu	ps|ROOT_ALLOMORPH @@ u|GEN_LOC_SG
+ręce	ręc|ROOT_ALLOMORPH @@ e|NOM_ACC_PL
+przyszliśmy	przy|PREFIX @@ sz|ROOT_ALLOMORPH @@ liśmy|PAST_1PL


### PR DESCRIPTION
## Summary

Adds the Chomsky SOTA 2026 tokenizer engineering artifacts to Slayer as an isolated benchmark package and static data mirror.

## What changed

- Added `bench/chomsky_sota2026/` with runnable scripts for synthetic morphology stress data, boundary/fertility/alignment evaluation, MorphBPE/SKMT-style constrained BPE, downstream smoke checks, and a neural char-level boundary tagger smoke run.
- Added generated reports under `bench/chomsky_sota2026/reports/`.
- Mirrored public dashboard artifacts under `public/data/chomsky-sota2026/`.

## Validation

Run from `bench/chomsky_sota2026/`:

```bash
python3 -m py_compile polish_morph_tokenizer.py polish_phoneme_tokenizer.py scripts/*.py
python3 scripts/generate_synthetic_morph_examples.py --count 100
python3 scripts/run_morph_bpe.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
python3 scripts/run_downstream_smoke.py --train data/morph_benchmark.json data/synthetic_morph_examples.json
python3 scripts/run_neural_segmenter.py --epochs 200 --train data/morph_benchmark.json data/synthetic_morph_examples.json
/Users/kacper/Local/Ventures/chomsky/.venv/bin/python scripts/evaluate_morph_segmentation.py
python3 scripts/export_sigmorphon_format.py
```

## Notes

The neural and MorphBPE scripts are smoke implementations for engineering validation, not final SOTA claims. Synthetic examples are marked `verified=false` and are stress data, not manually verified gold.
