### PR TITLE
feat: add Polish MMLU loader (Global-MMLU) to bench_mcq (mmlu_pl)

### DIFF
--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -90,11 +90,13 @@ def load_mmlu_pl(n, seed):
     L2I = {"A": 0, "B": 1, "C": 2, "D": 3}
     items = []
     for r in ds:
+        opts = [r["option_a"], r["option_b"], r["option_c"], r["option_d"]]
+        if any(o is None for o in opts):
+            continue
         gold = L2I.get(str(r["answer"]).strip().upper())
         if gold is None:
             continue
-        items.append({"q": r["question"],
-                      "options": [r["option_a"], r["option_b"], r["option_c"], r["option_d"]],
+        items.append({"q": r["question"], "options": opts,
                       "gold": gold, "cat": r.get("subject", "?")})
     return sample_strat(items, n, seed)
 

--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -2,7 +2,7 @@
 """Generic MCQ benchmark via ollama. Accuracy = decisive metric. Aggregates only
 (per-category accuracy COUNTS; no per-item inspection). Idempotent: skips if a
 result for (bench, seed) already exists. Usage: bench_mcq.py <bench> [N] [seed]
-benches: llmzszl belebele belebele_en pes include mmlu arc
+benches: llmzszl belebele belebele_en pes include mmlu arc mmlu_pl
 """
 import json, re, sys, time, random, csv, urllib.request, os, glob
 from collections import defaultdict
@@ -84,6 +84,20 @@ def load_mmlu(n, seed):
               "cat": r.get("subject", "?")} for r in ds]
     return sample_strat(items, n, seed)
 
+def load_mmlu_pl(n, seed):
+    from datasets import load_dataset
+    ds = load_dataset("CohereLabs/Global-MMLU", "pl", split="test")
+    L2I = {"A": 0, "B": 1, "C": 2, "D": 3}
+    items = []
+    for r in ds:
+        gold = L2I.get(str(r["answer"]).strip().upper())
+        if gold is None:
+            continue
+        items.append({"q": r["question"],
+                      "options": [r["option_a"], r["option_b"], r["option_c"], r["option_d"]],
+                      "gold": gold, "cat": r.get("subject", "?")})
+    return sample_strat(items, n, seed)
+
 def load_arc(n, seed):
     from datasets import load_dataset
     ds = load_dataset("allenai/ai2_arc", "ARC-Challenge", split="test")
@@ -99,6 +113,7 @@ BENCHES = {
     "llmzszl": (load_llmzszl, "pl"), "belebele": (load_belebele, "pl"),
     "belebele_en": (load_belebele_en, "en"), "pes": (load_pes, "pl"),
     "include": (load_include, "pl"), "mmlu": (load_mmlu, "en"), "arc": (load_arc, "en"),
+    "mmlu_pl": (load_mmlu_pl, "pl"),
 }
 
 def ask(model, it, sysp):


### PR DESCRIPTION
## Summary
Dodaje loader MCQ dla nowego publicznego zbioru PL i rejestruje go jako `mmlu_pl` w `bench/bench_mcq.py`, realizujac #3. Zbior: `CohereLabs/Global-MMLU` (config `pl`, split `test`), polskie tlumaczenie MMLU (57 kategorii), publiczne i pobieralne bez tokenu, deterministyczny test-split. Uzupelnia os polskiej wiedzy MCQ (komplementarnie do EN `mmlu`).

## What changed
- `bench/bench_mcq.py`: nowa funkcja `load_mmlu_pl(n, seed)` mapujaca `question` / `option_a..d` / `answer` (litera A-D) na generyczny schemat itemu (`q`, `options`, `gold`, `cat=subject`), reuzywa `sample_strat`.
- Rejestracja w `BENCHES`: `"mmlu_pl": (load_mmlu_pl, "pl")`.
- Dopisany `mmlu_pl` do listy benchy w docstringu.
- Bez nowej zaleznosci (`datasets` juz uzywany przez belebele/include/mmlu/arc).

## Validation
CPU-only, bez inferencji modelu i bez HF_TOKEN (`load_mmlu_pl(0, 42)`):

```
HF token in env: False
n = 14042
gold dist: {0: 3222, 1: 3462, 2: 3582, 3: 3776}
opt counts: {4: 14042}
n_categories: 57
sample.cat: professional_law
sample.gold: 1 -> option: Tak, ale tylko wtedy, gdy lokalne interesy w zakresie bezpieczenstwa przewazaja nad ciezarem handlu miedzystanowego.
```

Kazdy item ma 4 opcje, `gold` rozlozony rownomiernie A-D (brak degeneracji mapowania), 57 kategorii MMLU, pobieranie anonimowe (ungated).

## Notes
- Zgodne z zasada czystosci (README): publiczny, pobieralny, deterministyczny test-split, wylacznie do pomiaru.
- Liczby accuracy (Bielik/Qwen) do dolozenia na rigu z GPU; lokalnie brak warunkow do odpalenia modeli 9-11B.
- @kwikiel jako `cat` ustawilem `subject` (np. professional_law). Jezeli wolisz `subject_category` (STEM/Humanities/...), daj znac, zamienie.

Closes #3