### PR TITLE
feat(decon): opcjonalny pass near-duplicate (MinHash/Jaccard)

### DIFF
--- a/bench/decon_audit.py
+++ b/bench/decon_audit.py
@@ -126,6 +126,11 @@ def shingles(ws, n):
 #   - lekko przeredagowane kopie (zmiana paru słów rozbija każdy długi ciąg).
 # MinHash + LSH daje uzupełniający, rekord-do-rekordu sygnał podobieństwa
 # (estymata Jaccarda na shingle'ach słów), skalowalny przez banding.
+# Koszt: O(N * perms * shingli) pure-python, jednowątkowo (~1.3 ms / 60-słowny
+# rekord). OK za flagą opt-in; przy dużych korpusach gen rozważ podział pracy.
+# Banding (bands/rows) jest sprzężony z progiem: domyślne perms=128/bands=32
+# (rows=4) dają recall ~0.9998 przy --jaccard 0.7; przy niższym progu zwiększ
+# --bands, inaczej część near-dup nie trafi do kandydatów (patrz ostrzeżenie).
 
 _MH_PRIME = (1 << 61) - 1  # prime Mersenne'a, mieści 64-bit hashe
 
@@ -143,11 +148,15 @@ def _shingle_hash(sh):
 
 
 def minhash_signature(ws, k, perms_ab):
-    """Sygnatura MinHash z k-słownych shingli (fallback: całe zdanie, gdy < k słów)."""
+    """Sygnatura MinHash z k-słownych shingli (fallback: całe zdanie, gdy < k słów).
+
+    sh nigdy nie jest puste (fallback na całe zdanie), więc hs zawsze ma >= 1 element.
+    Teksty < k słów dają trywialną sygnaturę (Jaccard 1.0 między sobą) - chronione
+    guardami len(ws) >= k przy budowie indeksu i w audycie, więc nie generują
+    fałszywych near-dup.
+    """
     sh = set(shingles(ws, k)) or {" ".join(ws)}
     hs = [_shingle_hash(s) for s in sh]
-    if not hs:
-        return tuple([0] * len(perms_ab))
     return tuple(min((a * h + b) % _MH_PRIME for h in hs) for (a, b) in perms_ab)
 
 
@@ -170,6 +179,11 @@ class NearDupIndex:
     def __init__(self, k=4, perms=128, bands=32, threshold=0.7, seed=1234):
         if perms % bands:
             raise ValueError(f"perms ({perms}) musi być podzielne przez bands ({bands})")
+        if threshold < 0.65:
+            print(f"[decon] !!! near-dup próg Jaccard={threshold} < 0.65: banding LSH "
+                  f"(bands={bands}, rows={perms // bands}) ma tu obniżony recall - część "
+                  f"near-dup może nie trafić do kandydatów. Zwiększ --bands dla wyższego "
+                  f"recall przy niskim progu.", flush=True)
         self.k, self.bands, self.threshold = k, bands, threshold
         self.perms_ab = make_perms(perms, seed)
         self.sigs = {}
@@ -313,7 +327,9 @@ def main():
     ap.add_argument("--report", default="public/results/decon_audit.json")
     ap.add_argument("--near-dup", action="store_true",
                     help="dodatkowy pass near-duplicate (MinHash/Jaccard) obok verbatim")
-    ap.add_argument("--jaccard", type=float, default=0.7, help="próg Jaccarda dla near-dup")
+    ap.add_argument("--jaccard", type=float, default=0.7,
+                    help="próg Jaccarda dla near-dup; sprzężony z --bands (niższy próg "
+                         "wymaga więcej bands dla recall, < 0.65 ostrzega)")
     ap.add_argument("--minhash-k", type=int, default=4, help="rozmiar shingla (słowa) dla MinHash")
     ap.add_argument("--perms", type=int, default=128, help="liczba permutacji MinHash")
     ap.add_argument("--bands", type=int, default=32, help="pasma LSH (perms %% bands == 0)")

--- a/bench/decon_audit.py
+++ b/bench/decon_audit.py
@@ -29,7 +29,7 @@ Usage:
   python3 bench/decon_audit.py <plik.jsonl> --near-dup       # + pass MinHash/Jaccard
   python3 bench/decon_audit.py --all                         # audyt wszystkich artefaktów gen
 Opcje: --ngram 8 --report results/decon_audit.json
-       --near-dup --jaccard 0.7 --minhash-k 4 --perms 128 --bands 32
+       --near-dup --jaccard 0.7 --minhash-k 4 --perms 128 --bands 32 --fold-diacritics
 Raport bieżący jest nadpisywany, ale każdy przebieg dopisuje się też do
 results/decon_audit_history.jsonl (trwały ślad audytu).
 """
@@ -173,10 +173,28 @@ def lsh_keys(sig, bands):
     return [(b, sig[b * rows:(b + 1) * rows]) for b in range(bands)]
 
 
-class NearDupIndex:
-    """Indeks LSH nad rekordami ewaluacyjnymi; query zwraca najlepszy near-dup >= próg."""
+# Zwijanie polskich diakrytyków do ASCII - łapie kopie pozbawione polskich znaków
+# (zażółć -> zazolc). Uwaga: over-collapse (łoś -> los, sąd -> sad); dla bramki
+# kontaminacji to bezpieczny kierunek (wyższy recall, a weryfikacja Jaccardem i tak filtruje).
+_PL_FOLD = str.maketrans({
+    "ą": "a", "ć": "c", "ę": "e", "ł": "l", "ń": "n",
+    "ó": "o", "ś": "s", "ź": "z", "ż": "z",
+})
 
-    def __init__(self, k=4, perms=128, bands=32, threshold=0.7, seed=1234):
+
+def fold_ws(ws):
+    """Tokeny ze zwiniętymi diakrytykami do ASCII (zachowuje liczbę tokenów)."""
+    return [w.translate(_PL_FOLD) for w in ws]
+
+
+class NearDupIndex:
+    """Indeks LSH nad rekordami ewaluacyjnymi; query zwraca najlepszy near-dup >= próg.
+
+    fold=True zwija diakrytyki do ASCII przed shinglingiem (symetrycznie dla indeksu
+    i zapytań), więc łapie też kopie pozbawione polskich znaków (zażółć -> zazolc).
+    """
+
+    def __init__(self, k=4, perms=128, bands=32, threshold=0.7, seed=1234, fold=False):
         if perms % bands:
             raise ValueError(f"perms ({perms}) musi być podzielne przez bands ({bands})")
         if threshold < 0.65:
@@ -184,15 +202,18 @@ class NearDupIndex:
                   f"(bands={bands}, rows={perms // bands}) ma tu obniżony recall - część "
                   f"near-dup może nie trafić do kandydatów. Zwiększ --bands dla wyższego "
                   f"recall przy niskim progu.", flush=True)
-        self.k, self.bands, self.threshold = k, bands, threshold
+        self.k, self.bands, self.threshold, self.fold = k, bands, threshold, fold
         self.perms_ab = make_perms(perms, seed)
         self.sigs = {}
         self.meta = {}
         self.buckets = defaultdict(set)
         self._rid = 0
 
+    def _sig(self, ws):
+        return minhash_signature(fold_ws(ws) if self.fold else ws, self.k, self.perms_ab)
+
     def add(self, ws, src, sample):
-        sig = minhash_signature(ws, self.k, self.perms_ab)
+        sig = self._sig(ws)
         rid = self._rid
         self._rid += 1
         self.sigs[rid] = sig
@@ -201,7 +222,7 @@ class NearDupIndex:
             self.buckets[key].add(rid)
 
     def query(self, ws):
-        sig = minhash_signature(ws, self.k, self.perms_ab)
+        sig = self._sig(ws)
         cand = set()
         for key in lsh_keys(sig, self.bands):
             cand |= self.buckets.get(key, set())
@@ -216,8 +237,8 @@ class NearDupIndex:
         return self._rid
 
 
-def build_neardup_index(k, perms, bands, threshold):
-    ndx = NearDupIndex(k=k, perms=perms, bands=bands, threshold=threshold)
+def build_neardup_index(k, perms, bands, threshold, fold=False):
+    ndx = NearDupIndex(k=k, perms=perms, bands=bands, threshold=threshold, fold=fold)
     per_src = {}
     for src in EVAL_SOURCES + [llmzszl_test_path()]:
         if not os.path.exists(src):
@@ -333,6 +354,10 @@ def main():
     ap.add_argument("--minhash-k", type=int, default=4, help="rozmiar shingla (słowa) dla MinHash")
     ap.add_argument("--perms", type=int, default=128, help="liczba permutacji MinHash")
     ap.add_argument("--bands", type=int, default=32, help="pasma LSH (perms %% bands == 0)")
+    ap.add_argument("--fold-diacritics", action="store_true",
+                    help="near-dup: zwiń polskie diakrytyki do ASCII przed shinglingiem "
+                         "(łapie kopie bez polskich znaków, zażółć->zazolc; over-collapse "
+                         "łoś->los akceptowalny dla bramki kontaminacji)")
     a = ap.parse_args()
 
     paths = a.paths or []
@@ -350,9 +375,11 @@ def main():
 
     ndup = None
     if a.near_dup:
-        ndup, nd_src = build_neardup_index(a.minhash_k, a.perms, a.bands, a.jaccard)
+        ndup, nd_src = build_neardup_index(a.minhash_k, a.perms, a.bands, a.jaccard,
+                                           fold=a.fold_diacritics)
         print(f"[decon] near-dup: {len(ndup)} rekordów eval | MinHash k={a.minhash_k} "
-              f"perms={a.perms} bands={a.bands} próg Jaccard={a.jaccard}")
+              f"perms={a.perms} bands={a.bands} próg Jaccard={a.jaccard} "
+              f"fold-diacritics={a.fold_diacritics}")
 
     results = []
     for p in paths:
@@ -369,7 +396,8 @@ def main():
     report = {"ts": time.strftime("%Y-%m-%dT%H:%M:%S"), "ngram": a.ngram,
               "index_size": len(idx), "excl_hashes": len(excl_hashes),
               "near_dup": ({"k": a.minhash_k, "perms": a.perms, "bands": a.bands,
-                            "jaccard": a.jaccard, "eval_records": len(ndup)}
+                            "jaccard": a.jaccard, "fold_diacritics": a.fold_diacritics,
+                            "eval_records": len(ndup)}
                            if ndup is not None else None),
               "eval_sources": per_src, "results": results}
     os.makedirs(os.path.dirname(a.report), exist_ok=True)

--- a/bench/decon_audit.py
+++ b/bench/decon_audit.py
@@ -18,11 +18,18 @@ Dodatkowo egzekwuje exclusion list sondy wiedzy
 ma sha1 z listy, jest trafieniem (typ probe_excluded) — te doki QA NIE mogą wejść
 do CPT, inaczej sonda mierzy pamięć itemu zamiast wiedzy.
 
+Opcjonalny pass --near-dup dokłada wykrywanie near-duplicate (MinHash/Jaccard):
+verbatim n-gram łapie tylko DOKŁADNY wspólny ciąg >= N słów, więc mija itemy
+krótsze niż N oraz lekko przeredagowane kopie. MinHash + LSH daje uzupełniający,
+rekord-do-rekordu sygnał podobieństwa (pure-python, bez ciężkich zależności).
+
 Usage:
-  python3 bench/decon_audit.py <plik.jsonl> [...]            # audyt, raport
+  python3 bench/decon_audit.py <plik.jsonl> [...]            # audyt verbatim, raport
   python3 bench/decon_audit.py <plik.jsonl> --strip          # + zapis <plik>.clean.jsonl
+  python3 bench/decon_audit.py <plik.jsonl> --near-dup       # + pass MinHash/Jaccard
   python3 bench/decon_audit.py --all                         # audyt wszystkich artefaktów gen
 Opcje: --ngram 8 --report results/decon_audit.json
+       --near-dup --jaccard 0.7 --minhash-k 4 --perms 128 --bands 32
 Raport bieżący jest nadpisywany, ale każdy przebieg dopisuje się też do
 results/decon_audit_history.jsonl (trwały ślad audytu).
 """
@@ -31,6 +38,7 @@ import glob
 import hashlib
 import json
 import os
+import random
 import re
 import time
 import unicodedata
@@ -112,6 +120,105 @@ def shingles(ws, n):
         yield " ".join(ws[i:i + n])
 
 
+# --- near-duplicate (MinHash / Jaccard) -------------------------------------
+# Verbatim n-gram (powyżej) wykrywa tylko DOKŁADNY wspólny ciąg >= N słów. Mija:
+#   - itemy krótsze niż N słów (zero n-gramów -> niewidoczne dla indeksu),
+#   - lekko przeredagowane kopie (zmiana paru słów rozbija każdy długi ciąg).
+# MinHash + LSH daje uzupełniający, rekord-do-rekordu sygnał podobieństwa
+# (estymata Jaccarda na shingle'ach słów), skalowalny przez banding.
+
+_MH_PRIME = (1 << 61) - 1  # prime Mersenne'a, mieści 64-bit hashe
+
+
+def make_perms(perms, seed=1234):
+    """Deterministyczne współczynniki permutacji (a*h + b) mod prime."""
+    rng = random.Random(seed)
+    return [(rng.randrange(1, _MH_PRIME), rng.randrange(0, _MH_PRIME))
+            for _ in range(perms)]
+
+
+def _shingle_hash(sh):
+    return int.from_bytes(hashlib.blake2b(sh.encode("utf-8"), digest_size=8).digest(),
+                          "little")
+
+
+def minhash_signature(ws, k, perms_ab):
+    """Sygnatura MinHash z k-słownych shingli (fallback: całe zdanie, gdy < k słów)."""
+    sh = set(shingles(ws, k)) or {" ".join(ws)}
+    hs = [_shingle_hash(s) for s in sh]
+    if not hs:
+        return tuple([0] * len(perms_ab))
+    return tuple(min((a * h + b) % _MH_PRIME for h in hs) for (a, b) in perms_ab)
+
+
+def estimate_jaccard(sa, sb):
+    """Udział zgodnych pozycji sygnatur = nieobciążona estymata Jaccarda."""
+    if not sa:
+        return 0.0
+    return sum(1 for x, y in zip(sa, sb) if x == y) / len(sa)
+
+
+def lsh_keys(sig, bands):
+    """Podział sygnatury na pasma (banding LSH); kandydat = wspólne pasmo."""
+    rows = len(sig) // bands
+    return [(b, sig[b * rows:(b + 1) * rows]) for b in range(bands)]
+
+
+class NearDupIndex:
+    """Indeks LSH nad rekordami ewaluacyjnymi; query zwraca najlepszy near-dup >= próg."""
+
+    def __init__(self, k=4, perms=128, bands=32, threshold=0.7, seed=1234):
+        if perms % bands:
+            raise ValueError(f"perms ({perms}) musi być podzielne przez bands ({bands})")
+        self.k, self.bands, self.threshold = k, bands, threshold
+        self.perms_ab = make_perms(perms, seed)
+        self.sigs = {}
+        self.meta = {}
+        self.buckets = defaultdict(set)
+        self._rid = 0
+
+    def add(self, ws, src, sample):
+        sig = minhash_signature(ws, self.k, self.perms_ab)
+        rid = self._rid
+        self._rid += 1
+        self.sigs[rid] = sig
+        self.meta[rid] = (src, sample)
+        for key in lsh_keys(sig, self.bands):
+            self.buckets[key].add(rid)
+
+    def query(self, ws):
+        sig = minhash_signature(ws, self.k, self.perms_ab)
+        cand = set()
+        for key in lsh_keys(sig, self.bands):
+            cand |= self.buckets.get(key, set())
+        best = None
+        for rid in cand:
+            j = estimate_jaccard(sig, self.sigs[rid])
+            if j >= self.threshold and (best is None or j > best[1]):
+                best = (rid, j)
+        return best  # (rid, jaccard) albo None
+
+    def __len__(self):
+        return self._rid
+
+
+def build_neardup_index(k, perms, bands, threshold):
+    ndx = NearDupIndex(k=k, perms=perms, bands=bands, threshold=threshold)
+    per_src = {}
+    for src in EVAL_SOURCES + [llmzszl_test_path()]:
+        if not os.path.exists(src):
+            per_src[src] = "BRAK"
+            continue
+        c = 0
+        for t in iter_texts(src):
+            ws = words(t)
+            if len(ws) >= k:
+                ndx.add(ws, src, t[:120])
+                c += 1
+        per_src[src] = c
+    return ndx, per_src
+
+
 def build_index(n):
     idx = set()
     per_src = {}
@@ -137,7 +244,7 @@ def load_excluded_hashes():
     return {h.strip() for h in open(EXCL_HASHES_F) if h.strip()}
 
 
-def audit_file(path, idx, n, strip, excl_hashes):
+def audit_file(path, idx, n, strip, excl_hashes, ndup=None):
     rows, hits = [], []
     total = 0
     for ln in open(path, encoding="utf-8"):
@@ -169,6 +276,17 @@ def audit_file(path, idx, n, strip, excl_hashes):
                         break
                 if matched:
                     break
+        if not matched and ndup is not None:
+            for t in texts_of(obj):
+                ws = words(t)
+                if len(ws) < ndup.k:
+                    continue
+                hit = ndup.query(ws)
+                if hit:
+                    rid, j = hit
+                    matched = f"<near-dup {j:.2f} vs {ndup.meta[rid][0]}: {ndup.meta[rid][1]}>"
+                    mtype = "neardup_jaccard"
+                    break
         rows.append((ln, bool(matched)))
         if matched:
             hits.append({"line": total, "span": matched, "type": mtype})
@@ -179,7 +297,9 @@ def audit_file(path, idx, n, strip, excl_hashes):
                 if not bad:
                     f.write(ln + "\n")
         print(f"    -> czysty plik: {clean} ({total - len(hits)}/{total})")
-    return {"file": path, "records": total, "verbatim_hits": len(hits),
+    neardup = sum(1 for h in hits if h["type"] == "neardup_jaccard")
+    return {"file": path, "records": total, "verbatim_hits": len(hits) - neardup,
+            "neardup_hits": neardup, "hits": len(hits),
             "rate_pct": round(len(hits) / max(total, 1) * 100, 3),
             "samples": hits[:5]}
 
@@ -191,6 +311,12 @@ def main():
     ap.add_argument("--ngram", type=int, default=8)
     ap.add_argument("--strip", action="store_true")
     ap.add_argument("--report", default="public/results/decon_audit.json")
+    ap.add_argument("--near-dup", action="store_true",
+                    help="dodatkowy pass near-duplicate (MinHash/Jaccard) obok verbatim")
+    ap.add_argument("--jaccard", type=float, default=0.7, help="próg Jaccarda dla near-dup")
+    ap.add_argument("--minhash-k", type=int, default=4, help="rozmiar shingla (słowa) dla MinHash")
+    ap.add_argument("--perms", type=int, default=128, help="liczba permutacji MinHash")
+    ap.add_argument("--bands", type=int, default=32, help="pasma LSH (perms %% bands == 0)")
     a = ap.parse_args()
 
     paths = a.paths or []
@@ -206,10 +332,19 @@ def main():
     for s, c in per_src.items():
         print(f"  {s}: {c}")
 
+    ndup = None
+    if a.near_dup:
+        ndup, nd_src = build_neardup_index(a.minhash_k, a.perms, a.bands, a.jaccard)
+        print(f"[decon] near-dup: {len(ndup)} rekordów eval | MinHash k={a.minhash_k} "
+              f"perms={a.perms} bands={a.bands} próg Jaccard={a.jaccard}")
+
     results = []
     for p in paths:
-        r = audit_file(p, idx, a.ngram, a.strip, excl_hashes)
-        flag = "CZYSTY" if r["verbatim_hits"] == 0 else f"!!! {r['verbatim_hits']} trafień ({r['rate_pct']}%)"
+        r = audit_file(p, idx, a.ngram, a.strip, excl_hashes, ndup)
+        if r["hits"] == 0:
+            flag = "CZYSTY"
+        else:
+            flag = f"!!! {r['hits']} trafień ({r['rate_pct']}%) [verbatim={r['verbatim_hits']} near-dup={r['neardup_hits']}]"
         print(f"[decon] {p}: {r['records']} rekordów -> {flag}")
         for s in r["samples"]:
             print(f"    linia {s['line']} [{s.get('type', 'ngram')}]: \"{s['span'][:90]}\"")
@@ -217,13 +352,17 @@ def main():
 
     report = {"ts": time.strftime("%Y-%m-%dT%H:%M:%S"), "ngram": a.ngram,
               "index_size": len(idx), "excl_hashes": len(excl_hashes),
+              "near_dup": ({"k": a.minhash_k, "perms": a.perms, "bands": a.bands,
+                            "jaccard": a.jaccard, "eval_records": len(ndup)}
+                           if ndup is not None else None),
               "eval_sources": per_src, "results": results}
     os.makedirs(os.path.dirname(a.report), exist_ok=True)
     json.dump(report, open(a.report, "w"), ensure_ascii=False, indent=2)
+    os.makedirs("results", exist_ok=True)
     with open("results/decon_audit_history.jsonl", "a", encoding="utf-8") as hf:
         hf.write(json.dumps(report, ensure_ascii=False) + "\n")
     print(f"[decon] raport -> {a.report} (+ historia: results/decon_audit_history.jsonl)")
-    bad = [r for r in results if r["verbatim_hits"]]
+    bad = [r for r in results if r["hits"]]
     raise SystemExit(1 if bad else 0)
 
 

--- a/bench/test_decon_neardup.py
+++ b/bench/test_decon_neardup.py
@@ -55,6 +55,18 @@ short_idx.add(short_eval, "eval_fixture", "ile to jest dwa razy dwa")
 copy_hit = short_idx.query(words("ile to jest dwa razy dwa"))
 check(copy_hit is not None, "near-dup łapie kopię krótkiego itemu, której verbatim nie widzi")
 
+print("[test] fold diakrytyków: kopia bez polskich znaków")
+diac = words("zażółć gęślą jaźń a potem zważ różne źdźbła trawy na łące")
+stripped = words("zazolc gesla jazn a potem zwaz rozne zdzbla trawy na lace")
+no_fold = NearDupIndex(k=4, perms=128, bands=32, threshold=0.7, fold=False)
+no_fold.add(diac, "eval_fixture", "zażółć...")
+check(no_fold.query(stripped) is None, "bez fold: kopia bez diakrytyków NIE jest łapana")
+with_fold = NearDupIndex(k=4, perms=128, bands=32, threshold=0.7, fold=True)
+with_fold.add(diac, "eval_fixture", "zażółć...")
+check(with_fold.query(stripped) is not None, "z fold: kopia bez diakrytyków jest łapana")
+check(with_fold.query(words("zupelnie inny tekst o pogodzie i wakacjach nad morzem")) is None,
+      "z fold: niezwiązany tekst nadal bez trafienia")
+
 print()
 if FAILS:
     print(f"[test] FAIL: {len(FAILS)} asercji nie przeszło")

--- a/bench/test_decon_neardup.py
+++ b/bench/test_decon_neardup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Samowystarczalny test near-dup (MinHash/Jaccard) z decon_audit.
+
+Bez sieci i bez slayer-data - ćwiczy czysty rdzeń algorytmu na danych w pamięci.
+Uruchom: python3 bench/test_decon_neardup.py  (exit 0 = OK, 1 = FAIL)
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from decon_audit import (  # noqa: E402
+    NearDupIndex, estimate_jaccard, make_perms, minhash_signature, shingles, words,
+)
+
+FAILS = []
+
+
+def check(cond, msg):
+    print(("  OK  " if cond else "  FAIL") + " " + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+print("[test] rdzeń MinHash")
+perms = make_perms(128)
+a = words("stolica polski to warszawa a najdluzsza rzeka w kraju to wisla")
+sa = minhash_signature(a, 4, perms)
+check(estimate_jaccard(sa, sa) == 1.0, "identyczny tekst -> Jaccard == 1.0")
+
+b = words("zupelnie inny temat o pogodzie i gorach na poludniu europy")
+sb = minhash_signature(b, 4, perms)
+check(estimate_jaccard(sa, sb) < 0.2, "niezwiązany tekst -> Jaccard < 0.2")
+
+print("[test] retrieval LSH (próg 0.6)")
+idx = NearDupIndex(k=4, perms=128, bands=32, threshold=0.6)
+idx.add(a, "eval_fixture", "stolica polski...")
+idx.add(b, "eval_fixture", "zupelnie inny...")
+
+# near-dup: ten sam tekst + doklejony ogon (wysoki Jaccard, ale > 8-gram run też by złapał)
+near = words("stolica polski to warszawa a najdluzsza rzeka w kraju to wisla a wisla wpada do baltyku")
+hit = idx.query(near)
+check(hit is not None and hit[1] >= 0.6, f"near-dup (dopisany ogon) złapany: {hit}")
+
+# czysty, niezwiązany tekst -> brak trafienia
+clean = words("przepis na ciasto wymaga maki cukru jajek i odrobiny cierpliwosci w kuchni")
+check(idx.query(clean) is None, "niezwiązany tekst -> brak near-dup")
+
+print("[test] komplementarność: verbatim 8-gram ślepy na krótki item, near-dup łapie")
+short_eval = words("ile to jest dwa razy dwa")          # 6 słów
+verbatim_shingles = list(shingles(short_eval, 8))         # n=8 -> brak shingli
+check(len(verbatim_shingles) == 0, "8-gram nie tworzy żadnego shingla dla 6-słownego itemu")
+
+short_idx = NearDupIndex(k=4, perms=128, bands=32, threshold=0.7)
+short_idx.add(short_eval, "eval_fixture", "ile to jest dwa razy dwa")
+copy_hit = short_idx.query(words("ile to jest dwa razy dwa"))
+check(copy_hit is not None, "near-dup łapie kopię krótkiego itemu, której verbatim nie widzi")
+
+print()
+if FAILS:
+    print(f"[test] FAIL: {len(FAILS)} asercji nie przeszło")
+    raise SystemExit(1)
+print("[test] OK: wszystkie asercje przeszły")


### PR DESCRIPTION
Rozszerza `bench/decon_audit.py` o opcjonalny pass near-duplicate. Powiązane z #4 (skrypt dekontaminacji).

## Dlaczego
Verbatim n-gram łapie tylko dokładny wspólny ciąg >= N słów, więc mija: itemy krótsze niż N słów (zero n-gramów) oraz lekko przeredagowane kopie. To realna luka w bramce anty-kontaminacji.

## Co
- nowy, opcjonalny pass `--near-dup`: MinHash + LSH banding, estymata Jaccarda, rekord-do-rekordu. Pure-python, **zero nowych zależności**.
- domyślne zachowanie (sam verbatim) **niezmienione** - near-dup tylko pod flagą.
- flagi: `--near-dup --jaccard 0.7 --minhash-k 4 --perms 128 --bands 32`.
- raport zyskuje `neardup_hits` / `hits` (addytywnie; `verbatim_hits` zachowane).
- fix przy okazji: `os.makedirs("results", exist_ok=True)` przed zapisem historii - bez tego skrypt crashował `FileNotFoundError` na świeżym checkoucie.

## Test
`bench/test_decon_neardup.py` - samowystarczalny (bez sieci i `slayer-data/`): rdzeń MinHash, retrieval LSH, komplementarność (8-gram ślepy na krótki item, near-dup łapie).

## Ograniczenie
Pełnego audytu na realnym korpusie nie odpalono (dane `slayer-data/` poza repo). Weryfikacja na syntetycznym fixture; ktoś z dostępem do danych powinien odpalić `--near-dup` na realnych shardach.