### PR TITLE
fix(eval): odporność skryptów eval na puste/None wejścia (poquad, tokenizer)

### DIFF
--- a/bench/tokenizer_fertility.py
+++ b/bench/tokenizer_fertility.py
@@ -66,7 +66,7 @@ def main():
         for lang in ("pl", "en"):
             t, w, c = measure(tok, txt[lang])
             m[lang] = {"tpw": t / w if w else 0.0, "cpt": c / t if t else 0.0}
-        vocab = getattr(tok, "vocab_size", len(tok))
+        vocab = tok.vocab_size if hasattr(tok, "vocab_size") else len(tok)
         rows.append((label, vocab, m["pl"]["tpw"], m["pl"]["cpt"],
                      m["en"]["tpw"], m["en"]["cpt"],
                      m["pl"]["tpw"] / m["en"]["tpw"] if m["en"]["tpw"] else 0.0))

--- a/bench/tokenizer_fertility.py
+++ b/bench/tokenizer_fertility.py
@@ -36,6 +36,8 @@ def sample(lang, n):
             if 200 <= len(para) <= 1500:
                 out.append(para); c += 1; break
         if c >= n: break
+    if c < n:
+        print(f"  [uwaga] {lang}: pobrano {c}/{n} akapitów (wyczerpany strumień?)", flush=True)
     return "\n".join(out)
 
 def load_tok(repo):
@@ -63,13 +65,14 @@ def main():
         m = {}
         for lang in ("pl", "en"):
             t, w, c = measure(tok, txt[lang])
-            m[lang] = {"tpw": t / w, "cpt": c / t}
+            m[lang] = {"tpw": t / w if w else 0.0, "cpt": c / t if t else 0.0}
         vocab = getattr(tok, "vocab_size", len(tok))
         rows.append((label, vocab, m["pl"]["tpw"], m["pl"]["cpt"],
-                     m["en"]["tpw"], m["en"]["cpt"], m["pl"]["tpw"] / m["en"]["tpw"]))
+                     m["en"]["tpw"], m["en"]["cpt"],
+                     m["pl"]["tpw"] / m["en"]["tpw"] if m["en"]["tpw"] else 0.0))
         print(f"  zmierzono: {label}", flush=True)
 
-    rows.sort(key=lambda r: r[2])  # po fertility PL rosnąco (najlepszy u góry)
+    rows.sort(key=lambda r: r[2] if r[2] else float("inf"))  # fertility PL rosnąco (najlepszy u góry); zdegenerowany 0.0 na koniec
     print("\n" + "=" * 78)
     print(f"{'Tokenizer':<30}{'vocab':>8}{'TpW_PL':>8}{'CpT_PL':>8}{'TpW_EN':>8}{'PL/EN':>8}")
     print("-" * 78)

--- a/poquad_eval.py
+++ b/poquad_eval.py
@@ -132,9 +132,10 @@ def main():
     json.dump(results, open("/home/kacper/poquad_results.json", "w"), ensure_ascii=False, indent=2)
     print("\n================ PODSUMOWANIE (PoQuAD, n=100) ================")
     print(f"{'Model':<28}{'EM':>7}{'F1':>7}{'odp.F1':>9}{'abst.acc':>10}{'czas':>8}")
+    fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")
     for r in results:
         print(f"{r['display_name']:<28}{r['overall_EM']:>7}{r['overall_F1']:>7}"
-              f"{r['answerable_F1']:>9}{r['unanswerable_abstain_acc']:>10}{r['secs']:>7.0f}s")
+              f"{fmt(r['answerable_F1'], 9)}{fmt(r['unanswerable_abstain_acc'], 10)}{r['secs']:>7.0f}s")
 
 if __name__ == "__main__":
     main()

--- a/poquad_eval.py
+++ b/poquad_eval.py
@@ -102,12 +102,12 @@ def score(model, sample):
         if (i+1) % 10 == 0:
             print(f"  [{model}] {i+1}/{N}  ({time.time()-t0:.0f}s)", flush=True)
     n = len(sample)
-    overall_em = (has_em + no_ok) / n * 100
-    overall_f1 = (has_f1 + no_ok) / n * 100
+    overall_em = (has_em + no_ok) / n * 100 if n else None
+    overall_f1 = (has_f1 + no_ok) / n * 100 if n else None
     return {
         "model": model, "n": n,
-        "overall_EM": round(overall_em, 1),
-        "overall_F1": round(overall_f1, 1),
+        "overall_EM": round(overall_em, 1) if overall_em is not None else None,
+        "overall_F1": round(overall_f1, 1) if overall_f1 is not None else None,
         "answerable_n": has_n,
         "answerable_EM": round(has_em/has_n*100, 1) if has_n else None,
         "answerable_F1": round(has_f1/has_n*100, 1) if has_n else None,
@@ -134,7 +134,7 @@ def main():
     print(f"{'Model':<28}{'EM':>7}{'F1':>7}{'odp.F1':>9}{'abst.acc':>10}{'czas':>8}")
     fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")
     for r in results:
-        print(f"{r['display_name']:<28}{r['overall_EM']:>7}{r['overall_F1']:>7}"
+        print(f"{r['display_name']:<28}{fmt(r['overall_EM'], 7)}{fmt(r['overall_F1'], 7)}"
               f"{fmt(r['answerable_F1'], 9)}{fmt(r['unanswerable_abstain_acc'], 10)}{r['secs']:>7.0f}s")
 
 if __name__ == "__main__":

--- a/poquad_judge.py
+++ b/poquad_judge.py
@@ -71,8 +71,8 @@ def main():
             if (i + 1) % 20 == 0:
                 print(f"  {i+1}/100", flush=True)
         n = ans_n + no_n
-        acc = (ans_ok + no_ok) / n * 100
-        s = {"model": name, "judged_accuracy": round(acc, 1),
+        acc = (ans_ok + no_ok) / n * 100 if n else None
+        s = {"model": name, "judged_accuracy": round(acc, 1) if acc is not None else None,
              "answerable_correct": ans_ok, "answerable_n": ans_n,
              "answerable_acc": round(ans_ok / ans_n * 100, 1) if ans_n else None,
              "unanswerable_abstain": no_ok, "unanswerable_n": no_n}
@@ -81,10 +81,11 @@ def main():
     json.dump(summary, open("/home/kacper/poquad_judged.json", "w"), ensure_ascii=False, indent=2)
     print("\n===== DECISIVE (LLM-judge, n=100) =====")
     print(f"{'Model':<28}{'acc':>8}{'odp.acc':>10}{'abst.':>8}")
+    fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")
     for s in summary:
-        print(f"{s['model']:<28}{s['judged_accuracy']:>7}%{s['answerable_acc']:>9}%"
+        print(f"{s['model']:<28}{fmt(s['judged_accuracy'], 7)}%{fmt(s['answerable_acc'], 9)}%"
               f"{s['unanswerable_abstain']:>5}/{s['unanswerable_n']}")
-    if len(summary) == 2:
+    if len(summary) == 2 and all(s["judged_accuracy"] is not None for s in summary):
         a, b = summary
         win = a if a["judged_accuracy"] > b["judged_accuracy"] else b
         diff = abs(a["judged_accuracy"] - b["judged_accuracy"])


### PR DESCRIPTION
Trzy fixy odpornościowe w skryptach eval - wszystkie czysto edge-case'owe, ścieżka normalna (n>0, wartości != None) bajt-w-bajt niezmieniona.

## Zmiany
- **poquad_judge.py** (#46): `ZeroDivisionError` przy n=0. Guard na obliczeniu `acc`, na tabeli DECISIVE (helper `fmt()` renderuje `-` zamiast `format(None)`) oraz na bloku zwycięzcy (`all(... is not None)`). n=0 obsłużone end-to-end.
- **poquad_eval.py** (#47, #54): `TypeError` w tabeli gdy `answerable_F1`/`unanswerable_abstain_acc == None` -> helper `fmt()`. Dodatkowo guard `score()` przy n=0 dla `overall_EM`/`overall_F1` (dzielenie crashowało zanim dochodziło do tabeli).
- **bench/tokenizer_fertility.py** (#48, #55): `ZeroDivisionError` przy w/t/en=0 (bezpieczne dzielenie), ostrzeżenie o niepełnej próbce, sort key `r[2] if r[2] else inf` (zdegenerowany 0.0 na koniec rankingu, nie na szczyt), oraz lazy vocab (`tok.vocab_size if hasattr else len(tok)`).

## Weryfikacja
Sprawdzone wieloagentowo (2 rundy, w tym po review xfaang-ci): poprawność fixów, brak regresji (bajt-w-bajt na typowych danych), adversarial, lint, zgodność z issues. Brak osobnych testów - logika inline w `main()`, skrypty zależą od zahardkodowanych ścieżek i sieci HF; weryfikacja przez odtworzenie warunków crashu lokalnie.

## Zakres
- Closes #46
- Closes #47
- Closes #54
- Closes #55
- Refs #48 (punkt "niespójna definicja vocab" świadomie poza zakresem - kwestia semantyczno-dokumentacyjna, nie crash)