### PR TITLE
fix(eval): guardy ZeroDivisionError i format(None) w skryptach poquad + tokenizer

### DIFF
--- a/bench/tokenizer_fertility.py
+++ b/bench/tokenizer_fertility.py
@@ -36,6 +36,8 @@ def sample(lang, n):
             if 200 <= len(para) <= 1500:
                 out.append(para); c += 1; break
         if c >= n: break
+    if c < n:
+        print(f"  [uwaga] zebrano {c}/{n} akapitow ({lang}) - strumien wyczerpany", flush=True)
     return "\n".join(out)
 
 def load_tok(repo):
@@ -63,10 +65,11 @@ def main():
         m = {}
         for lang in ("pl", "en"):
             t, w, c = measure(tok, txt[lang])
-            m[lang] = {"tpw": t / w, "cpt": c / t}
-        vocab = getattr(tok, "vocab_size", len(tok))
+            m[lang] = {"tpw": t / w if w else 0.0, "cpt": c / t if t else 0.0}
+        vocab = tok.vocab_size if hasattr(tok, "vocab_size") else len(tok)
+        ratio = (m["pl"]["tpw"] / m["en"]["tpw"]) if m["en"]["tpw"] else 0.0
         rows.append((label, vocab, m["pl"]["tpw"], m["pl"]["cpt"],
-                     m["en"]["tpw"], m["en"]["cpt"], m["pl"]["tpw"] / m["en"]["tpw"]))
+                     m["en"]["tpw"], m["en"]["cpt"], ratio))
         print(f"  zmierzono: {label}", flush=True)
 
     rows.sort(key=lambda r: r[2])  # po fertility PL rosnąco (najlepszy u góry)

--- a/bench/tokenizer_fertility.py
+++ b/bench/tokenizer_fertility.py
@@ -72,7 +72,7 @@ def main():
                      m["en"]["tpw"], m["en"]["cpt"], ratio))
         print(f"  zmierzono: {label}", flush=True)
 
-    rows.sort(key=lambda r: r[2])  # po fertility PL rosnąco (najlepszy u góry)
+    rows.sort(key=lambda r: r[2] if r[2] else float("inf"))  # fertility PL rosnąco; zdegenerowany 0.0 na koniec
     print("\n" + "=" * 78)
     print(f"{'Tokenizer':<30}{'vocab':>8}{'TpW_PL':>8}{'CpT_PL':>8}{'TpW_EN':>8}{'PL/EN':>8}")
     print("-" * 78)

--- a/poquad_eval.py
+++ b/poquad_eval.py
@@ -102,12 +102,12 @@ def score(model, sample):
         if (i+1) % 10 == 0:
             print(f"  [{model}] {i+1}/{N}  ({time.time()-t0:.0f}s)", flush=True)
     n = len(sample)
-    overall_em = (has_em + no_ok) / n * 100
-    overall_f1 = (has_f1 + no_ok) / n * 100
+    overall_em = (has_em + no_ok) / n * 100 if n else None
+    overall_f1 = (has_f1 + no_ok) / n * 100 if n else None
     return {
         "model": model, "n": n,
-        "overall_EM": round(overall_em, 1),
-        "overall_F1": round(overall_f1, 1),
+        "overall_EM": round(overall_em, 1) if overall_em is not None else None,
+        "overall_F1": round(overall_f1, 1) if overall_f1 is not None else None,
         "answerable_n": has_n,
         "answerable_EM": round(has_em/has_n*100, 1) if has_n else None,
         "answerable_F1": round(has_f1/has_n*100, 1) if has_n else None,
@@ -132,9 +132,10 @@ def main():
     json.dump(results, open("/home/kacper/poquad_results.json", "w"), ensure_ascii=False, indent=2)
     print("\n================ PODSUMOWANIE (PoQuAD, n=100) ================")
     print(f"{'Model':<28}{'EM':>7}{'F1':>7}{'odp.F1':>9}{'abst.acc':>10}{'czas':>8}")
+    fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")
     for r in results:
-        print(f"{r['display_name']:<28}{r['overall_EM']:>7}{r['overall_F1']:>7}"
-              f"{r['answerable_F1']:>9}{r['unanswerable_abstain_acc']:>10}{r['secs']:>7.0f}s")
+        print(f"{r['display_name']:<28}{fmt(r['overall_EM'], 7)}{fmt(r['overall_F1'], 7)}"
+              f"{fmt(r['answerable_F1'], 9)}{fmt(r['unanswerable_abstain_acc'], 10)}{r['secs']:>7.0f}s")
 
 if __name__ == "__main__":
     main()

--- a/poquad_judge.py
+++ b/poquad_judge.py
@@ -71,8 +71,8 @@ def main():
             if (i + 1) % 20 == 0:
                 print(f"  {i+1}/100", flush=True)
         n = ans_n + no_n
-        acc = (ans_ok + no_ok) / n * 100
-        s = {"model": name, "judged_accuracy": round(acc, 1),
+        acc = (ans_ok + no_ok) / n * 100 if n else None
+        s = {"model": name, "judged_accuracy": round(acc, 1) if acc is not None else None,
              "answerable_correct": ans_ok, "answerable_n": ans_n,
              "answerable_acc": round(ans_ok / ans_n * 100, 1) if ans_n else None,
              "unanswerable_abstain": no_ok, "unanswerable_n": no_n}
@@ -81,10 +81,13 @@ def main():
     json.dump(summary, open("/home/kacper/poquad_judged.json", "w"), ensure_ascii=False, indent=2)
     print("\n===== DECISIVE (LLM-judge, n=100) =====")
     print(f"{'Model':<28}{'acc':>8}{'odp.acc':>10}{'abst.':>8}")
+    fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")
     for s in summary:
-        print(f"{s['model']:<28}{s['judged_accuracy']:>7}%{s['answerable_acc']:>9}%"
+        acc_s = f"{fmt(s['judged_accuracy'], 7)}%" if s["judged_accuracy"] is not None else f"{fmt(None, 7)} "
+        odp_s = f"{fmt(s['answerable_acc'], 9)}%" if s["answerable_acc"] is not None else f"{fmt(None, 9)} "
+        print(f"{s['model']:<28}{acc_s}{odp_s}"
               f"{s['unanswerable_abstain']:>5}/{s['unanswerable_n']}")
-    if len(summary) == 2:
+    if len(summary) == 2 and all(s["judged_accuracy"] is not None for s in summary):
         a, b = summary
         win = a if a["judged_accuracy"] > b["judged_accuracy"] else b
         diff = abs(a["judged_accuracy"] - b["judged_accuracy"])


### PR DESCRIPTION
## Summary

chirurgiczne guardy w trzech skryptach eval - puste probki i pola None nie wywalaja juz skryptu w polowie przebiegu (#54, #47, #46, #48, #55)

## What changed

- `poquad_eval.py`: guard `n=0` dla `overall_EM`/`overall_F1`; helper `fmt` w tabeli podsumowania gdy `answerable_F1` lub `unanswerable_abstain_acc` to None
- `poquad_judge.py`: guard `acc` przy `n=0`; None-safe wydruk `judged_accuracy`/`answerable_acc`; blok zwyciezcy tylko gdy oba modele maja wynik
- `bench/tokenizer_fertility.py`: bezpieczne dzielenie `tpw`/`cpt`/`ratio` przy `w=0`/`t=0`; lazy `vocab_size` zamiast eager `len(tok)`; ostrzezenie gdy strumien Wikipedia da mniej akapitow niz proszono

## Validation

CPU, lokalnie (Python 3.10):

```
python -m py_compile poquad_eval.py poquad_judge.py bench/tokenizer_fertility.py

python -c "import poquad_eval; r=poquad_eval.score('m',[]); assert r['overall_EM'] is None"
python -c "fmt=lambda v,w: format(v,f'>{w}') if v is not None else format('-',f'>{w}'); print(fmt(None,9))"
```

bez crasha na pustej probce i bez TypeError przy formatowaniu None w tabeli

## Notes

- bez zmian w logice scoringu dla `n>0` - tylko sciezki brzegowe
- pelny run na modelu (Ollama/GPU) poza lokalnym srodowiskiem reviewera

Closes #54
Closes #47
Closes #46
Closes #48
Closes #55