### PR TITLE
fix(frontend): nested nav active, external links target=_blank, rate_per_s=0 display

### DIFF
--- a/app/bench-explorer/explorer.jsx
+++ b/app/bench-explorer/explorer.jsx
@@ -149,7 +149,7 @@ export default function Explorer() {
             {rows.map((b) => (
               <tr key={b.id} className={b.status === "deprecated" ? "dep" : ""}>
                 <td>
-                  <div className="dn">{b.link ? <a href={b.link} rel="noopener">{b.nazwa}</a> : b.nazwa}</div>
+                  <div className="dn">{b.link ? <a href={b.link} target="_blank" rel="noopener noreferrer">{b.nazwa}</a> : b.nazwa}</div>
                   <div className="ds">{b.opis}{b.modele_zmierzone.length ? ` · zmierzone: ${b.modele_zmierzone.length} modele` : ""}</div>
                 </td>
                 <td className="mono-s">{b.typ_zadania || "—"}</td>

--- a/app/progress/console.jsx
+++ b/app/progress/console.jsx
@@ -65,7 +65,7 @@ export default function Console() {
             </div>
             <div className="ticks">
               <div className="tick"><div className="v acc">{eta != null ? "≈ " + fmt(eta) : "—"}</div><div className="k">ETA benchmarku</div></div>
-              <div className="tick"><div className="v">{(running && c.rate_per_s) || "—"}</div><div className="k">pyt/s</div></div>
+              <div className="tick"><div className="v">{running && c.rate_per_s != null ? c.rate_per_s : "—"}</div><div className="k">pyt/s</div></div>
             </div>
           </div>
         </div>

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -51,6 +51,7 @@ export default function Nav() {
   const pathname = (usePathname() || "/").replace(/\/+$/, "") || "/";
   const [open, setOpen] = useState(false);
   const close = () => setOpen(false);
+  const isActive = (href) => pathname === href || pathname.startsWith(href + "/");
   if (pathname === "/") return null; // ponytail: landing page (LEM) ships its own nav
   return (
     <header className="nav">
@@ -70,13 +71,13 @@ export default function Nav() {
       </button>
       <nav className={open ? "nlinks open" : "nlinks"}>
         {GROUPS.map((g) => {
-          const active = g.links.some(([href]) => href === pathname);
+          const active = g.links.some(([href]) => isActive(href));
           return (
             <div className={active ? "navgroup active" : "navgroup"} key={g.label}>
               <span className="navtop">{g.label}</span>
               <div className="navmenu">
                 {g.links.map(([href, label]) => (
-                  <a key={href} className={pathname === href ? "active" : ""} href={href} onClick={close}>
+                  <a key={href} className={isActive(href) ? "active" : ""} href={href} onClick={close}>
                     {label}
                   </a>
                 ))}


### PR DESCRIPTION
## Summary

trzy male poprawki UI z good-first issues - nawigacja na trasach zagniezdzonych, linki zewnetrzne w nowej karcie, wyswietlanie zera w polu pyt/s (#49, #50, #52)

## What changed

- `components/Nav.jsx`: helper `isActive` - `pathname === href || pathname.startsWith(href + '/')` dla grupy i linkow
- `app/bench-explorer/explorer.jsx`: `target="_blank"` + `rel="noopener noreferrer"` na linku benchmarku do HF
- `app/progress/console.jsx`: jawny `c.rate_per_s != null` zamiast falsy `||` - `0` renderuje sie jako `0`, nie `—`

## Validation

Lokalnie (Node v22.18.0):

```
npm run build
```

OK, 30/30 stron statycznych

recznie: `/bench-explorer/nowy` podswietla grupe pomiary; link HF otwiera nowa karte; `/progress` z `rate_per_s: 0` pokazuje `0` w polu pyt/s

## Notes

- bez zmian w `#51` (Lurker vs Observer) - to decyzja maintainera, nie w tym PR
- hydration mismatch w `app/progress/history.jsx` (Date.now w skali osi X) jest osobnym, wczesniejszym tematem - nie dotykany tutaj

Closes #49
Closes #50
Closes #52