### PR TITLE
fix(progress): rate_per_s===0 pokazuje '0' zamiast '—'

### DIFF
--- a/app/progress/console.jsx
+++ b/app/progress/console.jsx
@@ -65,7 +65,7 @@ export default function Console() {
             </div>
             <div className="ticks">
               <div className="tick"><div className="v acc">{eta != null ? "≈ " + fmt(eta) : "—"}</div><div className="k">ETA benchmarku</div></div>
-              <div className="tick"><div className="v">{(running && c.rate_per_s) || "—"}</div><div className="k">pyt/s</div></div>
+              <div className="tick"><div className="v">{running && c.rate_per_s != null ? c.rate_per_s : "—"}</div><div className="k">pyt/s</div></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #52

## Problem
`app/progress/console.jsx:68`:
```jsx
{(running && c.rate_per_s) || "—"}
```
`0` jest falsy, więc `0 || "—"` zwraca `"—"`. `status.py:96` ustawia `rate=0`, gdy `secs==0` (czyli `done=0` tuż po starcie joba), więc tick **pyt/s** pokazuje `—` zamiast `0`.

## Fix
Jawne sprawdzenie obecności wartości, spójne z sąsiednim tickiem ETA (`eta != null ? … : "—"`):
```jsx
{running && c.rate_per_s != null ? c.rate_per_s : "—"}
```

- `running && rate===0` → `0` ✅
- `running && rate===2.5` → `2.5` (bez zmian)
- `running && rate==null` → `—`
- `!running` → `—` (zachowane)

Zmiana w jednym pliku, bez efektów ubocznych.

🤖 Generated with [Claude Code](https://claude.com/claude-code)