### PR TITLE
fix(bench-explorer): zewnętrzne linki zbiorów otwierają się w nowej karcie

### DIFF
--- a/app/bench-explorer/explorer.jsx
+++ b/app/bench-explorer/explorer.jsx
@@ -149,7 +149,7 @@ export default function Explorer() {
             {rows.map((b) => (
               <tr key={b.id} className={b.status === "deprecated" ? "dep" : ""}>
                 <td>
-                  <div className="dn">{b.link ? <a href={b.link} rel="noopener">{b.nazwa}</a> : b.nazwa}</div>
+                  <div className="dn">{b.link ? <a href={b.link} target="_blank" rel="noopener noreferrer">{b.nazwa}</a> : b.nazwa}</div>
                   <div className="ds">{b.opis}{b.modele_zmierzone.length ? ` · zmierzone: ${b.modele_zmierzone.length} modele` : ""}</div>
                 </td>
                 <td className="mono-s">{b.typ_zadania || "—"}</td>


### PR DESCRIPTION
Closes #50

## Problem
`app/bench-explorer/explorer.jsx:152`:
```jsx
<a href={b.link} rel="noopener">{b.nazwa}</a>
```
Linki prowadzą do zewnętrznych zbiorów (HuggingFace). Bez `target="_blank"` atrybut `rel="noopener"` nic nie robi, a kliknięcie nawiguje w tej samej karcie SPA, gubiąc stan filtrów/sortowania/scroll.

## Fix
```jsx
<a href={b.link} target="_blank" rel="noopener noreferrer">{b.nazwa}</a>
```
Spójne z `bench-explorer/nowy/form.jsx` (które już używa `target="_blank" rel="noopener"`). Jeden plik, jedna linia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)