### PR TITLE
fix(poquad_eval): guard overall_EM/F1 na pustą próbkę

### DIFF
--- a/poquad_eval.py
+++ b/poquad_eval.py
@@ -102,12 +102,10 @@ def score(model, sample):
         if (i+1) % 10 == 0:
             print(f"  [{model}] {i+1}/{N}  ({time.time()-t0:.0f}s)", flush=True)
     n = len(sample)
-    overall_em = (has_em + no_ok) / n * 100
-    overall_f1 = (has_f1 + no_ok) / n * 100
     return {
         "model": model, "n": n,
-        "overall_EM": round(overall_em, 1),
-        "overall_F1": round(overall_f1, 1),
+        "overall_EM": round((has_em + no_ok)/n*100, 1) if n else None,
+        "overall_F1": round((has_f1 + no_ok)/n*100, 1) if n else None,
         "answerable_n": has_n,
         "answerable_EM": round(has_em/has_n*100, 1) if has_n else None,
         "answerable_F1": round(has_f1/has_n*100, 1) if has_n else None,

--- a/tests/test_poquad_eval.py
+++ b/tests/test_poquad_eval.py
@@ -1,0 +1,38 @@
+"""Regresja dla #54: score() nie może rzucać ZeroDivisionError przy pustej próbce.
+
+Test jest hermetyczny - stubuje huggingface_hub i nie dotyka ollamy/sieci.
+Dla pustego sample pętla po pytaniach nie wykonuje się, więc ask()/model
+nie są w ogóle używane; liczy się tylko agregacja overall_EM/overall_F1.
+
+Uruchomienie: `pytest tests/` albo `python3 tests/test_poquad_eval.py`.
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_poquad_eval():
+    # stub ciężkiej zależności, żeby import był bezsieciowy
+    sys.modules.setdefault(
+        "huggingface_hub", types.SimpleNamespace(hf_hub_download=lambda *a, **k: None)
+    )
+    spec = importlib.util.spec_from_file_location("poquad_eval", ROOT / "poquad_eval.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_score_empty_sample_no_zerodivision():
+    pe = _load_poquad_eval()
+    res = pe.score("dummy-model", [])
+    assert res["n"] == 0
+    assert res["overall_EM"] is None
+    assert res["overall_F1"] is None
+
+
+if __name__ == "__main__":
+    test_score_empty_sample_no_zerodivision()
+    print("OK: score() na pustej próbce nie rzuca ZeroDivisionError")


### PR DESCRIPTION
Closes #54

## Problem
`poquad_eval.py`, `score()`:
```python
overall_em = (has_em + no_ok) / n * 100   # n = len(sample)
overall_f1 = (has_f1 + no_ok) / n * 100
```
Brak guardu na `n=0` → `ZeroDivisionError`, czyli wcześniej niż w tabeli podsumowania (Refs #47). Ścieżka czysto teoretyczna (`N=100` zahardkodowane, `random.sample` padłby wcześniej przy populacji < 100) - zgłoszona dla kompletności.

## Fix
Guard spójny z sąsiednimi polami (`answerable_*`, `unanswerable_abstain_acc` już mają `if … else None`):
```python
"overall_EM": round((has_em + no_ok)/n*100, 1) if n else None,
"overall_F1": round((has_f1 + no_ok)/n*100, 1) if n else None,
```

## Test
`tests/test_poquad_eval.py` - hermetyczny (stubuje `huggingface_hub`, nie dotyka ollamy/sieci; przy pustym sample pętla nie woła modelu). Potwierdza `n==0` i `overall_EM/F1 is None` bez wyjątku.
```
$ python3 tests/test_poquad_eval.py
OK: score() na pustej próbce nie rzuca ZeroDivisionError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)