### PR TITLE
fix(bench): defensywny winner/margin + guard make_dashboard (single-model)

### DIFF
--- a/bench/bench_flores.py
+++ b/bench/bench_flores.py
@@ -73,14 +73,19 @@ def main():
                         "bleu_overall": round((pe_b+ep_b)/2, 1),
                         "secs": round(t1+t2, 1)})
         print(f"  [{name}] chrF={results[-1]['chrf_overall']} BLEU={results[-1]['bleu_overall']}", flush=True)
-    winner = max(results, key=lambda r: r["chrf_overall"])
     payload = {"benchmark": "flores", "metric": "chrF (PL↔EN, sacrebleu)",
                "n": len(pairs), "seed": SEED, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["chrf_overall"]-results[1]["chrf_overall"]), 1)}
+               "models": results}
+    sr = sorted(results, key=lambda r: r["chrf_overall"], reverse=True)
+    if len(sr) > 1:
+        payload["winner"] = sr[0]["display_name"]
+        payload["margin"] = round(sr[0]["chrf_overall"] - sr[1]["chrf_overall"], 1)
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/flores_n{len(pairs)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[flores] winner={winner['display_name']} +{payload['margin']} chrF", flush=True)
+    if "winner" in payload:
+        print(f"[flores] winner={payload['winner']} +{payload['margin']} chrF", flush=True)
+    else:
+        print(f"[flores] single-model ({sr[0]['display_name']}) - brak winner/margin", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/bench_gsm8k.py
+++ b/bench/bench_gsm8k.py
@@ -57,14 +57,19 @@ def main():
         results.append({"display_name": name, "tag": tag, "n": len(ds),
                         "accuracy": round(ok/len(ds)*100, 1), "secs": round(time.time()-t0, 1)})
         print(f"  [{name}] DONE acc={results[-1]['accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["accuracy"])
     payload = {"benchmark": "gsm8k", "metric": "accuracy (exact, final int) [EN regresja]",
                "n": len(ds), "seed": SEED, "lang": "en", "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["accuracy"]-results[1]["accuracy"]), 1)}
+               "models": results}
+    sr = sorted(results, key=lambda r: r["accuracy"], reverse=True)
+    if len(sr) > 1:
+        payload["winner"] = sr[0]["display_name"]
+        payload["margin"] = round(sr[0]["accuracy"] - sr[1]["accuracy"], 1)
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/gsm8k_n{len(ds)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[gsm8k] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    if "winner" in payload:
+        print(f"[gsm8k] winner={payload['winner']} +{payload['margin']}", flush=True)
+    else:
+        print(f"[gsm8k] single-model ({sr[0]['display_name']}) - brak winner/margin", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -156,14 +156,19 @@ def run(bench, n, seed):
                         "category_n": {c: ct_n[c] for c in ct_n if ct_n[c] >= 15},
                         "secs": round(time.time()-t0, 1)})
         print(f"  [{name}] DONE acc={results[-1]['accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["accuracy"])
     payload = {"benchmark": bench, "metric": "accuracy (MCQ, exact letter)" + (" [EN regresja]" if lang == "en" else ""),
                "n": len(sample), "seed": seed, "lang": lang, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["accuracy"]-results[1]["accuracy"]), 1)}
+               "models": results}
+    sr = sorted(results, key=lambda r: r["accuracy"], reverse=True)
+    if len(sr) > 1:                       # winner/margin tylko przy porownaniu (>=2 modele); margin top-2 wg wyniku
+        payload["winner"] = sr[0]["display_name"]
+        payload["margin"] = round(sr[0]["accuracy"] - sr[1]["accuracy"], 1)
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/{bench}_n{len(sample)}_s{seed}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[{bench}] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    if "winner" in payload:
+        print(f"[{bench}] winner={payload['winner']} +{payload['margin']}", flush=True)
+    else:
+        print(f"[{bench}] single-model ({sr[0]['display_name']}) - brak winner/margin", flush=True)
 
 if __name__ == "__main__":
     run(sys.argv[1], int(sys.argv[2]) if len(sys.argv) > 2 else 0, int(sys.argv[3]) if len(sys.argv) > 3 else 42)

--- a/bench/bench_poquad.py
+++ b/bench/bench_poquad.py
@@ -114,14 +114,19 @@ def main():
                         "unanswerable_abstain": f"{no_ok}/{no_n}",
                         "secs": round(raw[name]["infer_secs"] + time.time()-t0, 1)})
         print(f"  [{name}] judged_acc={results[-1]['judged_accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["judged_accuracy"])
     payload = {"benchmark": "poquad", "metric": "judged_accuracy (sędzia-LLM)", "judge": JUDGE_TAG,
                "n": len(smp), "seed": SEED, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["judged_accuracy"]-results[1]["judged_accuracy"]), 1)}
+               "models": results}
+    sr = sorted(results, key=lambda r: r["judged_accuracy"], reverse=True)
+    if len(sr) > 1:
+        payload["winner"] = sr[0]["display_name"]
+        payload["margin"] = round(sr[0]["judged_accuracy"] - sr[1]["judged_accuracy"], 1)
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/poquad_n{len(smp)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[poquad] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    if "winner" in payload:
+        print(f"[poquad] winner={payload['winner']} +{payload['margin']}", flush=True)
+    else:
+        print(f"[poquad] single-model ({sr[0]['display_name']}) - brak winner/margin", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/make_dashboard.py
+++ b/bench/make_dashboard.py
@@ -65,8 +65,10 @@ def main():
     lines.append("-" * 70)
     for p in benches:
         b, q = val(p, NAMES[0]), val(p, NAMES[1])
+        w, mg = p.get("winner"), p.get("margin")
+        zwy = (SHORT.get(w, w) + " +" + str(mg)) if w is not None and mg is not None else "-"
         lines.append(f"{LABEL.get(p['benchmark'],p['benchmark']):<16}{p['metric'][:21]:<22}"
-                     f"{(str(b)):>8}{(str(q)):>8}{SHORT.get(p['winner'],p['winner'])+' +'+str(p['margin']):>16}")
+                     f"{(str(b)):>8}{(str(q)):>8}{zwy:>16}")
     lines.append("")
     for p in benches:
         lines.append(f"[{LABEL.get(p['benchmark'],p['benchmark'])}] n={p['n']} seed={p.get('seed','-')} "
@@ -77,12 +79,14 @@ def main():
     rows = ""
     for p in benches:
         b, q = val(p, NAMES[0]), val(p, NAMES[1])
-        wb = "win" if p["winner"] == NAMES[0] else ""
-        wq = "win" if p["winner"] == NAMES[1] else ""
+        w, mg = p.get("winner"), p.get("margin")
+        wb = "win" if w == NAMES[0] else ""
+        wq = "win" if w == NAMES[1] else ""
+        zwy = (SHORT.get(w, w) + " +" + str(mg)) if w is not None and mg is not None else "-"
         rows += (f"<tr><td><b>{LABEL.get(p['benchmark'],p['benchmark'])}</b>"
                  f"<div class=meta>{p['metric']} · n={p['n']}</div></td>"
                  f"<td class='s {wb}'>{b}</td><td class='s {wq}'>{q}</td>"
-                 f"<td>{SHORT.get(p['winner'],p['winner'])} +{p['margin']}</td></tr>")
+                 f"<td>{zwy}</td></tr>")
     html = f"""<!doctype html><html lang=pl><head><meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
 <title>Bielik Slayer — Leaderboard</title><style>


### PR DESCRIPTION
Closes #40

## Problem
Produkcyjny `leaderboard.json` ma wpisy single-model (tylko Qwen). `bench_*.py` liczyły `margin=abs(results[0][m]-results[1][m])` → **IndexError** na `results[1]`, więc `winner`/`margin` nigdy nie trafiały do JSON, a `make_dashboard.py` wywalał **KeyError 'winner'** (SUMMARY.txt i dashboard.html nie powstawały, `dash()` w `run_all.sh` non-zero).

## Fix (root cause + symptom)
- `bench_mcq/poquad/gsm8k/flores.py`: `sorted(results, key=metric, reverse=True)`; `winner`/`margin` zapisywane tylko gdy `len(results)>1`; margin na **top-2 wg wyniku** (poprawny też dla 3+ modeli, nie kruche indeksy 0/1).
- `make_dashboard.py`: `p.get('winner')`/`p.get('margin')` z fallbackiem `'-'` (SUMMARY + HTML).

## Weryfikacja
Symulacja na produkcyjnym kształcie danych:
```
single-model -> brak winner (zero IndexError), komórka dashboardu '-'
2-model      -> winner=Bielik, margin=2.9, komórka 'Bielik +2.9'
```
Pełnego `run_all.sh` nie odpalałem (wymaga ollama + modele), ale logika winner/margin i render dashboardu są pokryte symulacją. `py_compile` 5/5 OK.

Zgodnie z CONTRIBUTING: guard na brzegi (single-model), determinizm, fix root-cause nie tylko symptomu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)