### PR TITLE
fix(bench): błędy inferencji nie liczone jako odpowiedzi modelu (czystość pomiaru)

### DIFF
--- a/bench/bench_gsm8k.py
+++ b/bench/bench_gsm8k.py
@@ -34,7 +34,12 @@ def ask(model, q):
     for a in range(3):
         try:
             with urllib.request.urlopen(req, timeout=180) as r:
-                return json.loads(r.read())["message"]["content"]
+                d = json.loads(r.read())
+            if isinstance(d, dict) and "error" in d:      # ollama: 200 + {'error':...} (np. brak modelu)
+                raise RuntimeError(f"ollama: {d['error']}")
+            return d["message"]["content"]
+        except RuntimeError:
+            raise                                          # twardy fail (np. brak modelu), nie ciche 0%
         except Exception as e:
             if a == 2: return ""
             time.sleep(2)

--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -137,20 +137,22 @@ def run(bench, n, seed):
     print(f"[{bench}] sample={len(sample)} seed={seed} lang={lang}", flush=True)
     results = []
     for name, tag in MODELS:
-        ok = bad = 0; ct_ok = defaultdict(int); ct_n = defaultdict(int); t0 = time.time()
+        ok = bad = errors = 0; ct_ok = defaultdict(int); ct_n = defaultdict(int); t0 = time.time()
         for i, it in enumerate(sample):
             out, nopt = ask(tag, it, sysp)
+            if isinstance(out, str) and (out.startswith("__ERR__") or out == ""):
+                errors += 1; continue          # blad inferencji != odpowiedz modelu - poza metrykami
             pred = parse_letter(out, nopt)
             if pred == -1: bad += 1
             c = int(pred == it["gold"]); ok += c
             ct_ok[it["cat"]] += c; ct_n[it["cat"]] += 1
             if (i+1) % 200 == 0:
-                print(f"  [{name}] {i+1}/{len(sample)} acc={ok/(i+1)*100:.1f}% ({time.time()-t0:.0f}s)", flush=True)
-        nn = len(sample)
+                print(f"  [{name}] {i+1}/{len(sample)} acc={ok/max(i+1-errors,1)*100:.1f}% ({time.time()-t0:.0f}s)", flush=True)
+        nn = len(sample); scored = nn - errors
         bycat_all = {c: round(ct_ok[c]/ct_n[c]*100, 1) for c in ct_n if ct_n[c] >= 15}
         bycat = {c: v for c, v in bycat_all.items() if ct_n[c] >= 20}
-        results.append({"display_name": name, "tag": tag, "n": nn,
-                        "accuracy": round(ok/nn*100, 1), "unparsed": bad,
+        results.append({"display_name": name, "tag": tag, "n": nn, "n_scored": scored, "errors": errors,
+                        "accuracy": round(ok/scored*100, 1) if scored else 0.0, "unparsed": bad,
                         "by_category_top": dict(sorted(bycat.items(), key=lambda x:-x[1])),
                         "by_category": bycat_all,
                         "category_n": {c: ct_n[c] for c in ct_n if ct_n[c] >= 15},

--- a/bench/bench_poquad.py
+++ b/bench/bench_poquad.py
@@ -91,8 +91,10 @@ def main():
     results = []
     for name, tag in MODELS:
         rows = raw[name]["rows"]
-        ans_ok = ans_n = no_ok = no_n = 0; f1s = []; t0 = time.time()
+        ans_ok = ans_n = no_ok = no_n = infer_errors = 0; f1s = []; t0 = time.time()
         for i, r in enumerate(rows):
+            if isinstance(r["pred"], str) and r["pred"].startswith("__ERR__"):
+                infer_errors += 1; continue       # blad inferencji poza ans_n/judged/F1
             if r["impossible"]:
                 no_n += 1; no_ok += int(is_abstain(r["pred"]))
             else:
@@ -107,8 +109,8 @@ def main():
             if (i+1) % 200 == 0: print(f"  [{name}] judge {i+1}/{len(rows)} ({time.time()-t0:.0f}s)", flush=True)
         n = ans_n + no_n
         # aggregate metrics only — no per-item inspection / sample dumps
-        results.append({"display_name": name, "tag": tag, "n": n,
-                        "judged_accuracy": round((ans_ok+no_ok)/n*100, 1),
+        results.append({"display_name": name, "tag": tag, "n": n, "infer_errors": infer_errors,
+                        "judged_accuracy": round((ans_ok+no_ok)/n*100, 1) if n else 0.0,
                         "judged_answerable_acc": round(ans_ok/ans_n*100, 1) if ans_n else None,
                         "squad_f1_answerable": round(sum(f1s)/len(f1s)*100, 1) if f1s else None,
                         "unanswerable_abstain": f"{no_ok}/{no_n}",


### PR DESCRIPTION
Closes #39

## Problem
Po wyczerpaniu retry `ask()/chat()` zwracają sentinel `__ERR__{e}` lub `''`, a downstream traktował to jak realną odpowiedź → **skażenie accuracy/F1**.
- `bench_mcq`: `parse_letter('__ERR__...', 5) == 4` (litera `E` z `ERR`) → dla PES (5 opcji) błąd sieci liczony jak odpowiedź `E`, dla 4-opcyjnych `-1`. PES to metryka decydująca, multi-seed na obciążonym GPU.
- `bench_poquad`: `__ERR__` szło do sędziego i F1 na śmieciowym tekście, bez licznika.
- `bench_gsm8k`: `{'error':...}` z ollamy (brak modelu) łapane jak timeout → ciche 0%.

## Fix
- **mcq**: `__ERR__`/`''` wykrywane przed `parse_letter` (`errors+=1; continue`), osobne pola `errors`/`n_scored`, accuracy po `n_scored`.
- **poquad**: `__ERR__` wykluczony z `ans_n`/judged/F1, pole `infer_errors`; guard gdy `n==0`.
- **gsm8k**: `ask()` po `json.loads` sprawdza `'error'` → **twardy `RuntimeError`** zamiast cichego 0%.

## Weryfikacja
```
parse_letter('__ERR__...', nopt=5) = 4  (bug potwierdzony -> 'E')
bramka: __ERR__ -> True, '' -> True, 'B' -> False
mcq: stara acc 54.0% (/100, skażona) -> nowa 60.0% (/90 ocenionych, errors=10)
gsm8k: brak modelu -> RuntimeError (twardy fail, nie 0%)
```
Pełnego benchu nie odpalałem (ollama+modele+GPU), ale logika sentinela, parse i metryk pokryta. `py_compile` 3/3 OK.

Zgodnie z CONTRIBUTING: zasada czystości pomiaru (błąd ≠ odpowiedź) i fail-loud (brak modelu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)