### PR TITLE
fix(bench): dashboard nie wywala się na leaderboardzie z jednym modelem (#40)

### DIFF
--- a/bench/_bench_common.py
+++ b/bench/_bench_common.py
@@ -1,0 +1,29 @@
+"""Wspólne pomocniki benchów.
+
+Celowo bez ciężkich zależności (tylko biblioteka standardowa), żeby moduł był
+importowalny samodzielnie i szybko testowalny. Benche są uruchamiane jako
+`python3 "$Q/bench_*.py"`, więc katalog skryptu trafia na sys.path[0] i
+`import _bench_common` działa niezależnie od bieżącego katalogu roboczego.
+"""
+
+
+def winner_margin(results, metric):
+    """Zwycięzca benchmarku i jego przewaga nad kolejnym modelem.
+
+    Zwraca ``{"winner": ..., "margin": ...}`` albo pusty dict, gdy modeli jest
+    mniej niż dwa — bez porównania nie ma zwycięzcy, a ``make_dashboard.py``
+    renderuje wtedy ``'-'``.
+
+    Przewagę liczymy względem faktycznego runner-upa (po posortowaniu), a nie
+    sztywnych ``results[0]``/``results[1]``. Dzięki temu:
+
+    * przy jednym modelu nie ma ``IndexError`` (realny stan produkcji, gdy drugi
+      model nie wyprodukował wyników) — to przyczyna #40,
+    * przy 3+ modelach margines jest liczony między zwycięzcą a drugim w
+      kolejności, a nie między dwoma pierwszymi wpisami listy.
+    """
+    if len(results) < 2:
+        return {}
+    ranked = sorted(results, key=lambda r: r[metric], reverse=True)
+    return {"winner": ranked[0]["display_name"],
+            "margin": round(ranked[0][metric] - ranked[1][metric], 1)}

--- a/bench/bench_flores.py
+++ b/bench/bench_flores.py
@@ -6,6 +6,7 @@ Needs HF_TOKEN in env (gated dataset). Writes bench_results/flores_n<N>_s<seed>.
 """
 import json, re, sys, os, time, random, urllib.request
 import sacrebleu
+from _bench_common import winner_margin
 from huggingface_hub import hf_hub_download
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
@@ -73,14 +74,12 @@ def main():
                         "bleu_overall": round((pe_b+ep_b)/2, 1),
                         "secs": round(t1+t2, 1)})
         print(f"  [{name}] chrF={results[-1]['chrf_overall']} BLEU={results[-1]['bleu_overall']}", flush=True)
-    winner = max(results, key=lambda r: r["chrf_overall"])
     payload = {"benchmark": "flores", "metric": "chrF (PL↔EN, sacrebleu)",
                "n": len(pairs), "seed": SEED, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["chrf_overall"]-results[1]["chrf_overall"]), 1)}
+               "models": results, **winner_margin(results, "chrf_overall")}
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/flores_n{len(pairs)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[flores] winner={winner['display_name']} +{payload['margin']} chrF", flush=True)
+    print(f"[flores] winner={payload.get('winner','-')} +{payload.get('margin','-')} chrF", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/bench_gsm8k.py
+++ b/bench/bench_gsm8k.py
@@ -3,6 +3,7 @@
 Aggregate accuracy only. Idempotent. Usage: bench_gsm8k.py [N] [seed]"""
 import json, re, sys, os, time, random, glob, urllib.request
 from datasets import load_dataset
+from _bench_common import winner_margin
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
 OUT = "/home/kacper/bench_results"
@@ -57,14 +58,12 @@ def main():
         results.append({"display_name": name, "tag": tag, "n": len(ds),
                         "accuracy": round(ok/len(ds)*100, 1), "secs": round(time.time()-t0, 1)})
         print(f"  [{name}] DONE acc={results[-1]['accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["accuracy"])
     payload = {"benchmark": "gsm8k", "metric": "accuracy (exact, final int) [EN regresja]",
                "n": len(ds), "seed": SEED, "lang": "en", "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["accuracy"]-results[1]["accuracy"]), 1)}
+               "models": results, **winner_margin(results, "accuracy")}
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/gsm8k_n{len(ds)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[gsm8k] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    print(f"[gsm8k] winner={payload.get('winner','-')} +{payload.get('margin','-')}", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/bench_mcq.py
+++ b/bench/bench_mcq.py
@@ -6,6 +6,7 @@ benches: llmzszl belebele belebele_en pes include mmlu arc
 """
 import json, re, sys, time, random, csv, urllib.request, os, glob
 from collections import defaultdict
+from _bench_common import winner_margin
 from huggingface_hub import hf_hub_download, HfApi
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
@@ -156,14 +157,12 @@ def run(bench, n, seed):
                         "category_n": {c: ct_n[c] for c in ct_n if ct_n[c] >= 15},
                         "secs": round(time.time()-t0, 1)})
         print(f"  [{name}] DONE acc={results[-1]['accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["accuracy"])
     payload = {"benchmark": bench, "metric": "accuracy (MCQ, exact letter)" + (" [EN regresja]" if lang == "en" else ""),
                "n": len(sample), "seed": seed, "lang": lang, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["accuracy"]-results[1]["accuracy"]), 1)}
+               "models": results, **winner_margin(results, "accuracy")}
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/{bench}_n{len(sample)}_s{seed}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[{bench}] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    print(f"[{bench}] winner={payload.get('winner','-')} +{payload.get('margin','-')}", flush=True)
 
 if __name__ == "__main__":
     run(sys.argv[1], int(sys.argv[2]) if len(sys.argv) > 2 else 0, int(sys.argv[3]) if len(sys.argv) > 3 else 42)

--- a/bench/bench_poquad.py
+++ b/bench/bench_poquad.py
@@ -6,6 +6,7 @@ as a subcategory. Writes /home/kacper/bench_results/poquad.json
 """
 import json, re, sys, time, random, os, urllib.request
 from collections import Counter
+from _bench_common import winner_margin
 from huggingface_hub import hf_hub_download
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
@@ -114,14 +115,12 @@ def main():
                         "unanswerable_abstain": f"{no_ok}/{no_n}",
                         "secs": round(raw[name]["infer_secs"] + time.time()-t0, 1)})
         print(f"  [{name}] judged_acc={results[-1]['judged_accuracy']}%", flush=True)
-    winner = max(results, key=lambda r: r["judged_accuracy"])
     payload = {"benchmark": "poquad", "metric": "judged_accuracy (sędzia-LLM)", "judge": JUDGE_TAG,
                "n": len(smp), "seed": SEED, "date": os.environ.get("RUN_DATE", ""),
-               "models": results, "winner": winner["display_name"],
-               "margin": round(abs(results[0]["judged_accuracy"]-results[1]["judged_accuracy"]), 1)}
+               "models": results, **winner_margin(results, "judged_accuracy")}
     os.makedirs(OUT, exist_ok=True)
     json.dump(payload, open(f"{OUT}/poquad_n{len(smp)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
-    print(f"[poquad] winner={winner['display_name']} +{payload['margin']}", flush=True)
+    print(f"[poquad] winner={payload.get('winner','-')} +{payload.get('margin','-')}", flush=True)
 
 if __name__ == "__main__":
     main()

--- a/bench/make_dashboard.py
+++ b/bench/make_dashboard.py
@@ -65,8 +65,10 @@ def main():
     lines.append("-" * 70)
     for p in benches:
         b, q = val(p, NAMES[0]), val(p, NAMES[1])
+        w, m = p.get("winner"), p.get("margin")
+        zwy = f"{SHORT.get(w, w)} +{m}" if w is not None and m is not None else "-"
         lines.append(f"{LABEL.get(p['benchmark'],p['benchmark']):<16}{p['metric'][:21]:<22}"
-                     f"{(str(b)):>8}{(str(q)):>8}{SHORT.get(p['winner'],p['winner'])+' +'+str(p['margin']):>16}")
+                     f"{(str(b)):>8}{(str(q)):>8}{zwy:>16}")
     lines.append("")
     for p in benches:
         lines.append(f"[{LABEL.get(p['benchmark'],p['benchmark'])}] n={p['n']} seed={p.get('seed','-')} "
@@ -77,12 +79,14 @@ def main():
     rows = ""
     for p in benches:
         b, q = val(p, NAMES[0]), val(p, NAMES[1])
-        wb = "win" if p["winner"] == NAMES[0] else ""
-        wq = "win" if p["winner"] == NAMES[1] else ""
+        w, m = p.get("winner"), p.get("margin")
+        wb = "win" if w == NAMES[0] else ""
+        wq = "win" if w == NAMES[1] else ""
+        zwy = f"{SHORT.get(w, w)} +{m}" if w is not None and m is not None else "-"
         rows += (f"<tr><td><b>{LABEL.get(p['benchmark'],p['benchmark'])}</b>"
                  f"<div class=meta>{p['metric']} · n={p['n']}</div></td>"
                  f"<td class='s {wb}'>{b}</td><td class='s {wq}'>{q}</td>"
-                 f"<td>{SHORT.get(p['winner'],p['winner'])} +{p['margin']}</td></tr>")
+                 f"<td>{zwy}</td></tr>")
     html = f"""<!doctype html><html lang=pl><head><meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
 <title>Bielik Slayer — Leaderboard</title><style>

--- a/bench/tests/test_winner_margin_dashboard.py
+++ b/bench/tests/test_winner_margin_dashboard.py
@@ -1,0 +1,94 @@
+"""Regresja dla #40: leaderboard z jednym modelem nie może wywalać dashboardu.
+
+Pokrywa dwie warstwy fiksa:
+  * `_bench_common.winner_margin` — brak IndexError przy <2 modelach, poprawny
+    margines względem runner-upa przy 3+ modelach,
+  * `make_dashboard.main` — generuje SUMMARY.txt i dashboard.html (zamiast
+    KeyError: 'winner') na realnym kształcie produkcyjnym, gdzie payload nie ma
+    pól winner/margin.
+
+Bez zależności od ciężkich bibliotek benchów ani od GPU/sieci. Uruchamialny
+zarówno przez `pytest`, jak i wprost: `python3 bench/tests/test_winner_margin_dashboard.py`.
+"""
+import json
+import os
+import sys
+import tempfile
+
+BENCH_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if BENCH_DIR not in sys.path:
+    sys.path.insert(0, BENCH_DIR)
+
+from _bench_common import winner_margin  # noqa: E402
+import make_dashboard  # noqa: E402
+
+
+def test_winner_margin_empty():
+    assert winner_margin([], "accuracy") == {}
+
+
+def test_winner_margin_single_model_no_indexerror():
+    # przyczyna #40: jeden model w results -> wcześniej results[1] => IndexError
+    one = [{"display_name": "Qwen3.5-9B", "accuracy": 55.0}]
+    assert winner_margin(one, "accuracy") == {}
+
+
+def test_winner_margin_two_models():
+    res = [{"display_name": "Bielik-11B-v3.0-Instruct", "accuracy": 60.0},
+           {"display_name": "Qwen3.5-9B", "accuracy": 57.5}]
+    assert winner_margin(res, "accuracy") == {"winner": "Bielik-11B-v3.0-Instruct", "margin": 2.5}
+
+
+def test_winner_margin_three_models_uses_runner_up():
+    # margines liczony zwycięzca - drugi w kolejności, niezależnie od porządku listy
+    res = [{"display_name": "C", "accuracy": 40.0},
+           {"display_name": "A", "accuracy": 80.0},
+           {"display_name": "B", "accuracy": 75.0}]
+    assert winner_margin(res, "accuracy") == {"winner": "A", "margin": 5.0}
+
+
+def _run_dashboard_with(payloads):
+    """Uruchamia make_dashboard.main() na tymczasowym katalogu z podanymi payloadami.
+    Zwraca (summary_text, html_text)."""
+    tmp = tempfile.mkdtemp(prefix="slayer_dash_")
+    for i, p in enumerate(payloads):
+        with open(os.path.join(tmp, f"{p['benchmark']}_n{p['n']}_s{i}.json"), "w", encoding="utf-8") as fh:
+            json.dump(p, fh, ensure_ascii=False)
+    old_out = make_dashboard.OUT
+    make_dashboard.OUT = tmp
+    try:
+        make_dashboard.main()
+        summary = open(os.path.join(tmp, "SUMMARY.txt"), encoding="utf-8").read()
+        html = open(os.path.join(tmp, "dashboard.html"), encoding="utf-8").read()
+    finally:
+        make_dashboard.OUT = old_out
+    return summary, html
+
+
+def test_dashboard_single_model_does_not_crash():
+    # dokładnie stan produkcji: jeden model, payload bez winner/margin
+    payload = {"benchmark": "pes", "metric": "accuracy (MCQ, exact letter)", "n": 100,
+               "seed": 42, "models": [{"display_name": "Qwen3.5-9B", "accuracy": 55.0}]}
+    summary, html = _run_dashboard_with([payload])
+    # zwycięzca nieokreślony -> '-' zamiast wyjątku
+    assert "-" in summary
+    assert "PES" in summary
+    assert "Qwen3.5-9B" in html  # wynik modelu nadal renderowany
+
+
+def test_dashboard_two_models_shows_winner():
+    payload = {"benchmark": "pes", "metric": "accuracy (MCQ, exact letter)", "n": 100, "seed": 42,
+               "models": [{"display_name": "Bielik-11B-v3.0-Instruct", "accuracy": 60.0},
+                          {"display_name": "Qwen3.5-9B", "accuracy": 57.5}],
+               "winner": "Bielik-11B-v3.0-Instruct", "margin": 2.5}
+    summary, html = _run_dashboard_with([payload])
+    assert "Bielik-11B-v3" in summary and "+2.5" in summary
+    assert "+2.5" in html
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS  {fn.__name__}")
+    print(f"\n{len(fns)} testów OK")


### PR DESCRIPTION
Zamyka #40.

## Problem
Produkcyjny `leaderboard.json` ma wpisy z **jednym modelem** (sam Qwen), bez pól `winner`/`margin`. `make_dashboard.py` czytał `p['winner']`/`p['margin']` wprost w sekcji SUMMARY (oraz w HTML), co dawało odtwarzalny `KeyError: 'winner'` — `SUMMARY.txt` i `dashboard.html` nigdy nie powstawały, a `dash()` w `run_all.sh` kończył się non-zero. `tally` (linia 56) był już odporny dzięki `.get`, więc samo `leaderboard.json` się zapisywało — i to maskowało crash kolejnych dwóch artefaktów.

**Przyczyna źródłowa** jest w benchach: `margin = abs(results[0][m] - results[1][m])` ze sztywnymi indeksami `0/1`. Przy jednym modelu `results[1]` rzuca `IndexError`, więc `winner`/`margin` nie były nigdy zapisywane (dokładnie stan produkcji). Te indeksy są też kruche przy 3+ modelach — margines liczony między dwoma pierwszymi wpisami listy, a nie względem zwycięzcy.

## Repro (przed fiksem)
`make_dashboard` na payloadzie jednomodelowym (bez `winner`/`margin`):
```
PRZED fiksem -> KeyError: 'winner'
```

## Zmiana
- **`bench/_bench_common.py`** (nowy, tylko stdlib, importowalny samodzielnie — benche jadą jako `python3 "$Q/bench_*.py"`, więc katalog skryptu jest na `sys.path[0]`): helper `winner_margin(results, metric)` zwraca pusty dict przy `<2` modelach (bez porównania nie ma zwycięzcy → dashboard pokaże `'-'`), a margines liczy względem **faktycznego runner-upa** (po sort), poprawnie też przy 3+ modelach.
- **`bench_mcq.py`, `bench_poquad.py`, `bench_flores.py`, `bench_gsm8k.py`**: użycie helpera zamiast `results[0]/[1]`; status `print` odporny na brak pól (`.get(..., '-')`).
- **`make_dashboard.py`**: SUMMARY i HTML korzystają z `p.get('winner')`/`p.get('margin')` z bezpiecznym `'-'`.
- **`bench/tests/test_winner_margin_dashboard.py`**: regresja — helper dla 0/1/2/3 modeli oraz `make_dashboard.main()` na payloadzie jednomodelowym (było: `KeyError`, jest: SUMMARY+HTML z `'-'`). Bez GPU/sieci.

## Test (po fiksie)
```
$ python3 bench/tests/test_winner_margin_dashboard.py
  PASS  test_dashboard_single_model_does_not_crash
  PASS  test_dashboard_two_models_shows_winner
  PASS  test_winner_margin_empty
  PASS  test_winner_margin_single_model_no_indexerror
  PASS  test_winner_margin_three_models_uses_runner_up
  PASS  test_winner_margin_two_models

6 testów OK
```
Plik testowy działa też pod `pytest`.

## Decyzje / zakres
- Przy jednym modelu **świadomie nie wymyślam zwycięzcy** — payload nie dostaje `winner`/`margin`, a dashboard renderuje `'-'`. `tally` nie zalicza wygranej (warunek `margin > 0`), więc wynik zbiorczy pozostaje uczciwy.
- Nie ruszam zahardkodowanego `OUT = "/home/kacper/bench_results"` w `make_dashboard.py` — to osobny problem (por. #59/#72), poza zakresem #40; test podmienia `OUT` na katalog tymczasowy.
- Sentinele błędów inferencji (`__ERR__`) skażające metryki to oddzielny wątek (#39) — tu nietknięty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)