### PR TITLE
fix(repro): ujednolic BENCH_OUT zamiast zahardkodowanego /home/kacper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Nasza teza „super tanio + epsilon": **startujemy z Qwen3.5-9B** (bije Bielika 
 
 Wymagania: [ollama](https://ollama.com), Python 3.10+. `pip install -e .` (lub `uv sync`).
 
+Wyniki benchmarków trafiają do `~/bench_results` (lub `export BENCH_OUT=/ścieżka/do/wyników`).
+
 ```bash
 ollama pull qwen3.5:9b
 ollama pull hf.co/speakleash/Bielik-11B-v3.0-Instruct-GGUF:Q4_K_M

--- a/bench/bench_poquad.py
+++ b/bench/bench_poquad.py
@@ -2,7 +2,8 @@
 """PoQuAD via ollama + LLM-judge (decisive). Usage: bench_poquad.py [N] [seed]
 Phase 1: inference (Bielik, Qwen3.5-9B). Phase 2: judge each answerable answer
 for semantic correctness with an ollama judge model (JUDGE_TAG). Also keeps SQuAD-F1
-as a subcategory. Writes $BENCH_OUT/poquad_n{N}_s{seed}.json (default ~/bench_results).
+as a subcategory. Writes $BENCH_OUT/poquad_n<n>_s<seed>.json where n = drawn sample
+size (min of CLI N and dataset size; default ~/bench_results).
 """
 import json, re, sys, time, random, os, urllib.request
 from collections import Counter
@@ -73,9 +74,10 @@ def judge(q, golds, pred):
     return toks[-1] == "TAK" if toks else out.strip().startswith("T")
 
 def main():
-    if os.path.exists(f"{OUT}/poquad_n{N}_s{SEED}.json"):
-        print(f"[poquad] SKIP — n{N} s{SEED} już jest", flush=True); return
     smp = sample()
+    out_file = os.path.join(OUT, f"poquad_n{len(smp)}_s{SEED}.json")
+    if os.path.exists(out_file):
+        print(f"[poquad] SKIP — n{len(smp)} s{SEED} już jest", flush=True); return
     nimp = sum(x["impossible"] for x in smp)
     print(f"[poquad] n={len(smp)} ({len(smp)-nimp} odp + {nimp} nieodp) seed={SEED} judge={JUDGE_TAG}", flush=True)
     raw = {}
@@ -119,7 +121,7 @@ def main():
                "n": len(smp), "seed": SEED, "date": os.environ.get("RUN_DATE", ""),
                "models": results, **winner_margin(results, "judged_accuracy")}
     os.makedirs(OUT, exist_ok=True)
-    json.dump(payload, open(f"{OUT}/poquad_n{len(smp)}_s{SEED}.json", "w"), ensure_ascii=False, indent=2)
+    json.dump(payload, open(out_file, "w"), ensure_ascii=False, indent=2)
     print(f"[poquad] winner={payload.get('winner','-')} +{payload.get('margin','-')}", flush=True)
 
 if __name__ == "__main__":

--- a/bench/bench_poquad.py
+++ b/bench/bench_poquad.py
@@ -2,7 +2,7 @@
 """PoQuAD via ollama + LLM-judge (decisive). Usage: bench_poquad.py [N] [seed]
 Phase 1: inference (Bielik, Qwen3.5-9B). Phase 2: judge each answerable answer
 for semantic correctness with an ollama judge model (JUDGE_TAG). Also keeps SQuAD-F1
-as a subcategory. Writes /home/kacper/bench_results/poquad.json
+as a subcategory. Writes $BENCH_OUT/poquad_n{N}_s{seed}.json (default ~/bench_results).
 """
 import json, re, sys, time, random, os, urllib.request
 from collections import Counter
@@ -10,7 +10,7 @@ from _bench_common import winner_margin
 from huggingface_hub import hf_hub_download
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
-OUT = "/home/kacper/bench_results"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 N = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
 SEED = int(sys.argv[2]) if len(sys.argv) > 2 else 42
 ABSTAIN = "Brak odpowiedzi w tekście"

--- a/bench/decon_neardup.py
+++ b/bench/decon_neardup.py
@@ -182,15 +182,15 @@ def main():
         for s in r["samples"]:
             print(f"    linia {s['line']} [{s['type']}] score={s['score']}")
         results.append(r)
-        if (a.strip or a.strip_diacritics) and any(
-                should_strip(raw, fold, a.strip, a.strip_diacritics) for _, raw, fold in rows):
+        strip_flags = [should_strip(raw, fold, a.strip, a.strip_diacritics)
+                       for _, raw, fold in rows]
+        if (a.strip or a.strip_diacritics) and any(strip_flags):
             clean = p.rsplit(".jsonl", 1)[0] + ".clean.jsonl"
             with open(clean, "w", encoding="utf-8") as f:
-                for ln, raw_hit, fold_hit in rows:
-                    if not should_strip(raw_hit, fold_hit, a.strip, a.strip_diacritics):
+                for (ln, _, _), strip in zip(rows, strip_flags):
+                    if not strip:
                         f.write(ln + "\n")
-            kept = sum(1 for _, raw_hit, fold_hit in rows
-                       if not should_strip(raw_hit, fold_hit, a.strip, a.strip_diacritics))
+            kept = sum(1 for s in strip_flags if not s)
             print(f"    -> czysty plik: {clean} ({kept}/{r['records']})")
 
     report = {"ts": time.strftime("%Y-%m-%dT%H:%M:%S"), "tool": "decon_neardup",

--- a/bench/make_dashboard.py
+++ b/bench/make_dashboard.py
@@ -3,7 +3,7 @@
 Run after each job so partial results are always viewable. Partial-safe."""
 import json, os, glob, datetime
 
-OUT = "/home/kacper/bench_results"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 NAMES = ["Bielik-11B-v3.0-Instruct", "Qwen3.5-9B"]
 SHORT = {"Bielik-11B-v3.0-Instruct": "Bielik-11B-v3", "Qwen3.5-9B": "Qwen3.5-9B"}
 PRIMARY = {"poquad": "judged_accuracy", "llmzszl": "accuracy", "belebele": "accuracy",

--- a/poquad_eval.py
+++ b/poquad_eval.py
@@ -6,11 +6,12 @@ SQuAD 2.0 style scoring:
   - unanswerable: correct iff model abstains ("Brak odpowiedzi w tekście")
 Deterministic 100-question sample (seed=42), identical for both models.
 """
-import json, re, sys, time, random, urllib.request
+import json, re, sys, time, random, os, urllib.request
 from collections import Counter
 from huggingface_hub import hf_hub_download
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 N = 100
 SEED = 42
 ABSTAIN = "Brak odpowiedzi w tekście"
@@ -129,7 +130,8 @@ def main():
         results.append(res)
         print(json.dumps({k: v for k, v in res.items() if k != "rows"}, ensure_ascii=False, indent=2), flush=True)
         print(flush=True)
-    json.dump(results, open("/home/kacper/poquad_results.json", "w"), ensure_ascii=False, indent=2)
+    os.makedirs(OUT, exist_ok=True)
+    json.dump(results, open(os.path.join(OUT, "poquad_results.json"), "w"), ensure_ascii=False, indent=2)
     print("\n================ PODSUMOWANIE (PoQuAD, n=100) ================")
     print(f"{'Model':<28}{'EM':>7}{'F1':>7}{'odp.F1':>9}{'abst.acc':>10}{'czas':>8}")
     fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")

--- a/poquad_judge.py
+++ b/poquad_judge.py
@@ -6,9 +6,10 @@ For each answerable question the judge decides TAK/NIE: czy odpowiedz modelu jes
 merytorycznie poprawna wzgledem zlotej odpowiedzi (niezaleznie od formy/odmiany).
 Unanswerable: correct iff model abstained (already flagged). Output: single accuracy.
 """
-import json, re, urllib.request, time
+import json, re, os, urllib.request, time
 
 JUDGE = "http://127.0.0.1:8088/v1/chat/completions"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 JUDGE_MODEL = "qwen3.5-35b-a3b"
 
 def strip_think(s):
@@ -48,7 +49,7 @@ def judge(question, golds, pred):
             time.sleep(2)
 
 def main():
-    d = json.load(open("/home/kacper/poquad_results.json"))
+    d = json.load(open(os.path.join(OUT, "poquad_results.json")))
     summary = []
     for r in d:
         name = r["display_name"]
@@ -78,7 +79,8 @@ def main():
              "unanswerable_abstain": no_ok, "unanswerable_n": no_n}
         summary.append(s)
         print(json.dumps(s, ensure_ascii=False), flush=True)
-    json.dump(summary, open("/home/kacper/poquad_judged.json", "w"), ensure_ascii=False, indent=2)
+    os.makedirs(OUT, exist_ok=True)
+    json.dump(summary, open(os.path.join(OUT, "poquad_judged.json"), "w"), ensure_ascii=False, indent=2)
     print("\n===== DECISIVE (LLM-judge, n=100) =====")
     print(f"{'Model':<28}{'acc':>8}{'odp.acc':>10}{'abst.':>8}")
     fmt = lambda v, w: format(v, f">{w}") if v is not None else format("-", f">{w}")


### PR DESCRIPTION
## Co robi
- `bench_poquad.py`, `make_dashboard.py`, `poquad_eval.py`, `poquad_judge.py` → `BENCH_OUT` (domyślnie `~/bench_results`)
- `decon_neardup.py`: cache `should_strip` zamiast 3× na rekord
- README: notka o `export BENCH_OUT=...`

## Dlaczego
Reprodukcja z README nie działała poza maszyną Kacpra — zahardkodowane `/home/kacper`.

Closes #72
Closes #81
Closes #73

Po merge: `git clone` + sekcja Reprodukcja w README powinny działać na każdej maszynie (CPU-only, bez ollama wymagane do samego sprawdzenia ścieżki wyjścia).