### PR TITLE
build(deps): podbij undici 6.26.0 do 6.27.0 (4 podatności)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1044,9 +1044,9 @@
       "license": "0BSD"
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Co robi
- Podbija transytywną zależność `undici` z **6.26.0** do **6.27.0** w samym `package-lock.json`
- `undici` wciąga `@vercel/blob@2.4.0` (`^6.23.0`); bez zmian w `package.json` i `overrides`

## Dlaczego
Cztery alerty Dependabota ([#2](https://github.com/slayerlabs/slayer/security/dependabot/2), [#3](https://github.com/slayerlabs/slayer/security/dependabot/3), [#4](https://github.com/slayerlabs/slayer/security/dependabot/4), [#5](https://github.com/slayerlabs/slayer/security/dependabot/5)) dotyczą `undici < 6.27.0`. Wersja 6.27.0 to release bezpieczeństwa, który łata komplet advisory:

| GHSA | CVE | Ciężkość | Opis |
|------|-----|----------|------|
| [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q) | CVE-2026-12151 | **Wysoka** | DoS klienta WebSocket (obchodzenie limitu fragmentów) |
| [GHSA-p88m-4jfj-68fv](https://github.com/advisories/GHSA-p88m-4jfj-68fv) | CVE-2026-9679 | Średnia | Wstrzyknięcie nagłówka HTTP przez dekodowanie Set-Cookie |
| [GHSA-g8m3-5g58-fq7m](https://github.com/advisories/GHSA-g8m3-5g58-fq7m) | CVE-2026-11525 | Niska | Obniżenie atrybutu SameSite w Set-Cookie |
| [GHSA-35p6-xmwp-9g52](https://github.com/advisories/GHSA-35p6-xmwp-9g52) | CVE-2026-6733 | Niska | Zatrucie kolejki odpowiedzi HTTP (reuse keep-alive) |

Zastępuje identyczny PR Dependabota #69 (ten sam diff lockfile).

## Weryfikacja
```bash
npm ci
npm ls undici --all   # undici@6.27.0 via @vercel/blob
npm audit             # 0 vulnerabilities
```

Ryzyko minimalne: patch w tej samej linii major (6.x), tylko lockfile, bez zmian w kodzie aplikacji.