### PR TITLE
fix(repro): dokoncz BENCH_OUT - usun pozostale /home/kacper i zle results/

### DIFF
--- a/bench/bench_flores.py
+++ b/bench/bench_flores.py
@@ -10,7 +10,7 @@ from _bench_common import winner_margin
 from huggingface_hub import hf_hub_download
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
-OUT = "/home/kacper/bench_results"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 N = int(sys.argv[1]) if len(sys.argv) > 1 else 300
 SEED = int(sys.argv[2]) if len(sys.argv) > 2 else 42
 TOKEN = os.environ.get("HF_TOKEN")

--- a/bench/bench_gsm8k.py
+++ b/bench/bench_gsm8k.py
@@ -6,7 +6,7 @@ from datasets import load_dataset
 from _bench_common import winner_margin
 
 OLLAMA = "http://127.0.0.1:11434/api/chat"
-OUT = "/home/kacper/bench_results"
+OUT = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 N = int(sys.argv[1]) if len(sys.argv) > 1 else 0
 SEED = int(sys.argv[2]) if len(sys.argv) > 2 else 42
 MODELS = [

--- a/bench/compare.py
+++ b/bench/compare.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Czyste porównanie per-kategoria: gdzie Bielik bije Qwena (i odwrotnie).
 Tylko agregaty accuracy per kategoria ze zbioru — żadnej inspekcji itemów.
-Czyta /home/kacper/bench_results/*.json (najwiekszy run per benchmark)."""
+Czyta $BENCH_OUT/*.json (domyslnie ~/bench_results; najwiekszy run per benchmark)."""
 import json, glob, os
 from collections import defaultdict
 
-BR = "/home/kacper/bench_results"
+BR = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 NB, NQ = "Bielik-11B-v3.0-Instruct", "Qwen3.5-9B"
 LABEL = {"llmzszl": "LLMzSzŁ (domeny)", "pes": "PES (specjalizacje)", "belebele": "Belebele", "poquad": "PoQuAD"}
 

--- a/bench/knowledge_probe.py
+++ b/bench/knowledge_probe.py
@@ -175,7 +175,7 @@ def main():
         flag = f" | PUSTE: {empty} (artefakt harnessu!)" if empty else ""
         print(f"[{name}] acc: {acc}{flag}")
 
-    os.makedirs("results", exist_ok=True)
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
     json.dump({"probe": PROBE_F, "n": len(probe), "seed": a.seed, "judge": JUDGE,
                "note": "probe z korpusu CPT; doki QA z exclusion list NIE moga wejsc do treningu",
                "results": results}, open(OUT, "w"), ensure_ascii=False, indent=2)

--- a/bench/status.py
+++ b/bench/status.py
@@ -4,7 +4,7 @@ No dependency on the queue internals; safe to run on a loop every ~20s."""
 import json, re, os, time, glob
 from datetime import datetime
 
-BR = "/home/kacper/bench_results"
+BR = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
 LOG = f"{BR}/queue.log"
 TS = re.compile(r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)\s")
 NB, NQ = "Bielik-11B-v3.0-Instruct", "Qwen3.5-9B"

--- a/bench/verify_probe_golds.py
+++ b/bench/verify_probe_golds.py
@@ -36,7 +36,7 @@ if not KEY:
 
 PROBE_F = "slayer-data/knowledge/probe_v1.jsonl"
 SRC_F = "slayer-data/knowledge/sources/wiki_pl_focus.jsonl"
-OUT = "results/probe_golds_verification.json"
+OUT = "public/results/probe_golds_verification.json"
 
 SYS = ("Weryfikujesz pytanie testowe. Dostajesz ŹRÓDŁO (fragmenty artykułu), PYTANIE i GOLD "
        "(wzorcową odpowiedź). Oceń: 'ok' = gold poprawnie odpowiada na pytanie i wynika ze źródła; "
@@ -111,7 +111,7 @@ def main():
               "ambiguous": ambiguous, "pct_bad_gold": pct_bad,
               "bad_line_indices": sorted(bad_lines),
               "decision_rule": "<10% zlych => sonda zostaje z raportem bledu; >=10% => przebudowa"}
-    os.makedirs("results", exist_ok=True)
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
     json.dump(report, open(OUT, "w"), ensure_ascii=False, indent=2)
     print(f"[golds] werdykty: {dict(verdicts)} | niejednoznaczne: {ambiguous} | "
           f"złe goldy: {pct_bad}% -> {OUT}", flush=True)

--- a/llmzszl_eval.py
+++ b/llmzszl_eval.py
@@ -4,7 +4,7 @@
 Accuracy is the decisive metric. Stratified sample by exam 'type' (seed 42).
 Subcategory breakdown per exam type. Usage: python3 llmzszl_eval.py [N]
 """
-import json, re, sys, time, random, urllib.request
+import json, re, sys, os, time, random, urllib.request
 from collections import defaultdict
 from huggingface_hub import hf_hub_download
 
@@ -106,7 +106,9 @@ def main():
         res = score(tag, sample); res["display_name"] = name
         results.append(res)
         print(json.dumps(res, ensure_ascii=False, indent=2), flush=True)
-    json.dump(results, open("/home/kacper/llmzszl_results.json", "w"), ensure_ascii=False, indent=2)
+    out_dir = os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))
+    os.makedirs(out_dir, exist_ok=True)
+    json.dump(results, open(os.path.join(out_dir, "llmzszl_results.json"), "w"), ensure_ascii=False, indent=2)
     print("\n===== LLMzSzŁ (MCQ, decisive accuracy) =====")
     print(f"{'Model':<28}{'accuracy':>10}{'unparsed':>10}{'czas':>8}")
     for r in results:


### PR DESCRIPTION
Dokończenie #86 (które ujednoliciło `BENCH_OUT` tylko częściowo - zostały twarde `/home/kacper` i błędne `results/`). Repro pada out-of-the-box na każdej maszynie poza autorską.

## Zmiany (jeden temat: ścieżki wyników)
- `compare.py`, `bench_gsm8k.py`, `bench_flores.py`, `status.py`: `OUT`/`BR` -> `os.environ.get("BENCH_OUT", os.path.expanduser("~/bench_results"))` (identyczny wzorzec jak #86).
- `llmzszl_eval.py`: dodano `import os`, output do `BENCH_OUT` + `os.makedirs` (wcześniej hardkod `/home/kacper` i `NameError` - brak `import os`).
- `verify_probe_golds.py`: `results/` -> `public/results/` (serwowane) + `makedirs(os.path.dirname(OUT))`.
- `knowledge_probe.py`: naprawa `makedirs("results")` -> `makedirs(os.path.dirname(OUT))` (OUT już był `public/results/...`, więc makedirs tworzył zły katalog -> crash zapisu).

## Weryfikacja
Sprawdzone wieloagentowo: `BENCH_OUT` respektowane (env -> custom, brak -> `~/bench_results`), ścieżki write/read spójne z make_dashboard (#86), logika benchów nietknięta, brak regresji. Bonus: usuwa preexisting `F401` (nieużywany `import os`) w compare.py.

## Poza zakresem
- `decon_audit.py` (ten sam `results/` FileNotFoundError) - naprawiany w otwartym **#36**, pomijam by uniknąć konfliktu. Refs #36.
- `run_all.sh` / `publish.sh` - skrypty host-specific (kolejka/deploy z konkretnej maszyny).

Closes #92